### PR TITLE
Bumped fundraiser and multisig to v0.17

### DIFF
--- a/fundraiser/src/contract_abi.sw
+++ b/fundraiser/src/contract_abi.sw
@@ -1,4 +1,4 @@
-library abi;
+library contract_abi;
 
 dep data_structures;
 

--- a/fundraiser/src/main.sw
+++ b/fundraiser/src/main.sw
@@ -1,6 +1,6 @@
 contract;
 
-dep abi;
+dep contract_abi;
 dep data_structures;
 dep errors;
 dep events;
@@ -21,7 +21,7 @@ use std::{
     token::transfer,
 };
 
-use abi::Fundraiser;
+use contract_abi::Fundraiser;
 use data_structures::{AssetInfo, Campaign, CampaignInfo, Pledge};
 use errors::{CampaignError, CreationError, UserError};
 use events::{CancelledCampaignEvent, ClaimedEvent, CreatedCampaignEvent, PledgedEvent, UnpledgedEvent};

--- a/multisig-wallet/src/contract_abi.sw
+++ b/multisig-wallet/src/contract_abi.sw
@@ -1,4 +1,4 @@
-library abi;
+library contract_abi;
 
 dep data_structures;
 

--- a/multisig-wallet/src/main.sw
+++ b/multisig-wallet/src/main.sw
@@ -5,7 +5,7 @@ contract;
 //      - change the "data" in the Tx hashing from b256 to vec
 
 // Our library dependencies
-dep abi;
+dep contract_abi;
 dep data_structures;
 dep errors;
 dep events;
@@ -31,7 +31,7 @@ use std::{
 use core::num::*;
 
 // Our library imports
-use abi::MultiSignatureWallet;
+use contract_abi::MultiSignatureWallet;
 use data_structures::{Transaction, User};
 use errors::{ExecutionError, InitError};
 use events::{ExecutedEvent, TransferEvent};

--- a/multisig-wallet/src/main.sw
+++ b/multisig-wallet/src/main.sw
@@ -15,7 +15,7 @@ use std::{
     address::Address,
     assert::require,
     b512::B512,
-    constants::BASE_ASSET_ID,
+    constants::ZERO_B256,
     context::{call_frames::contract_id, this_balance},
     contract_id::ContractId,
     ecr::ec_recover_address,
@@ -65,7 +65,7 @@ impl MultiSignatureWallet for Contract {
 
         let mut user_index = 0;
         while user_index < 25 {
-            require(~Address::from(BASE_ASSET_ID) != users[user_index].identity, InitError::AddressCannotBeZero);
+            require(~Address::from(ZERO_B256) != users[user_index].identity, InitError::AddressCannotBeZero);
             require(users[user_index].weight != 0, InitError::WeightingCannotBeZero);
             storage.weighting.insert(users[user_index].identity, users[user_index].weight);
             user_index = user_index + 1;
@@ -124,7 +124,7 @@ impl MultiSignatureWallet for Contract {
         storage.nonce = storage.nonce + 1;
 
         match to {
-            Identity::Address(address) => transfer_to_output(value, asset_id, address), Identity::ContractId(contract) => force_transfer_to_contract(value, asset_id, contract), 
+            Identity::Address(address) => transfer_to_output(value, asset_id, address), Identity::ContractId(address) => force_transfer_to_contract(value, asset_id, address), 
         };
 
         log(TransferEvent {


### PR DESCRIPTION
## Type of change

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Fundraiser & Multisig
    - Renamed abi library to contract_abi
    - Adjusted usage accordingly to new name
- Multisig
    - Renamed contract to address
    - Changed import from BASE_ASSET_ID (which is now a ContractId type) to ZERO_B256

## Notes

- ABI is now a forbidden keyword
- contract is now a forbidden keyword
