### PR TITLE
Update `action-fuel-toolchain` to v0.2.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,7 +72,7 @@ jobs:
         uses: FuelLabs/action-fuel-toolchain@v0.2.0
         with:
           name: my-toolchain
-          components: forc@0.19.2, fuel-core@0.10.1
+          components: forc@0.19.2, fuel-core@0.9.8
 
       - name: Check Sway formatting
         run: forc fmt --path ${{ matrix.project }} --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,10 @@ jobs:
         run: rustup component add rustfmt
 
       - name: Install Fuel toolchain
-        uses: FuelLabs/action-fuel-toolchain@v0.1.0
+        uses: FuelLabs/action-fuel-toolchain@v0.2.0
+        with:
+          name: my-toolchain
+          components: forc@0.19.2, fuel-core@0.10.1
 
       - name: Check Sway formatting
         run: forc fmt --path ${{ matrix.project }} --check


### PR DESCRIPTION
## Type of change

- Other (describe below)

## Changes

The following changes have been made:

- Forc is set to 0.19.2
- Core is set to 0.9.8

## Notes

- Once some recently created PRs go in then this can be bumped up again
- Core has an older version because it has breaking changes that have not been propagated throughout other projects. The result is upstream code suddenly failing the tests since underlying config is now different. There are other PRs that are meant to address this by bumping up the SDK version to the latest however at this time these configuration changes have not yet been addressed therefore those tests cannot be updated right now. This older version should allow #195 to go in next.

## Related Issues

Closes #199 
