### PR TITLE
Update command used to build the dao project

### DIFF
--- a/dao-voting/README.md
+++ b/dao-voting/README.md
@@ -48,7 +48,7 @@ There are two commands required to run the tests
 1. Build the asset used for depositing into the dao-voting
    
    ```bash
-   forc build --path tests/artifacts/asset/
+   forc build --path tests/artifacts/gov_token 
    ```
 
 2. Run the tests


### PR DESCRIPTION
## Type of change

- Documentation

## Changes

The following changes have been made:

The old command uses a directory `tests/artifacts/asset`. This no longer exists in the project. The PR updates the command to use the directory `tests/artifacts/gov_token` that seems to have replaced the former directory.

## Notes

% forc build --path tests/artifacts/gov_token
  Compiled library "core".
  Compiled library "std".
  Compiled contract "gov_token".
  Bytecode size is 1708 bytes.


## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #\<issue number\>
