### PR TITLE
Standardize Tests Across Repo

### DIFF
--- a/NFT/tests/functions/admin.rs
+++ b/NFT/tests/functions/admin.rs
@@ -44,7 +44,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_admin_not_set() {
+    async fn when_admin_not_set() {
         let (_deploy_wallet, owner1, _owner2) = setup().await;
 
         admin(&owner1.contract).await;

--- a/NFT/tests/functions/approve.rs
+++ b/NFT/tests/functions/approve.rs
@@ -66,7 +66,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_token_owner_does_not_exist() {
+    async fn when_token_owner_does_not_exist() {
         let (_deploy_wallet, owner1, owner2) = setup().await;
 
         // let approved_identity = Option::Some(Identity::Address(owner2.wallet.address().into()));
@@ -76,7 +76,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_token_does_not_map_to_existing_token() {
+    async fn when_token_does_not_map_to_existing_token() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 
         // constructor(false, &deploy_wallet.contract, &Option::None(), 1).await;
@@ -90,7 +90,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_sender_is_not_owner() {
+    async fn when_sender_is_not_owner() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 
         // constructor(false, &deploy_wallet.contract, &Option::None(), 1).await;'

--- a/NFT/tests/functions/burn.rs
+++ b/NFT/tests/functions/burn.rs
@@ -67,7 +67,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_token_owner_does_not_exist() {
+    async fn when_token_owner_does_not_exist() {
         let (_deploy_wallet, owner1, _owner2) = setup().await;
 
         burn(&owner1.contract, 0).await;
@@ -75,7 +75,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_token_does_not_exist() {
+    async fn when_token_does_not_exist() {
         let (deploy_wallet, owner1, _owner2) = setup().await;
 
         // constructor(false, &deploy_wallet.contract, &Option::None(), 1).await;
@@ -90,7 +90,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_sender_is_not_owner() {
+    async fn when_sender_is_not_owner() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 
         // constructor(false, &deploy_wallet.contract, &Option::None(), 1).await;

--- a/NFT/tests/functions/constructor.rs
+++ b/NFT/tests/functions/constructor.rs
@@ -45,7 +45,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_initalized_twice() {
+    async fn when_initalized_twice() {
         let (deploy_wallet, owner1, _owner2) = setup().await;
 
         // constructor(false, &deploy_wallet.contract, &Option::None(), 1).await;
@@ -57,7 +57,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_token_supply_is_zero() {
+    async fn when_token_supply_is_zero() {
         let (deploy_wallet, owner1, _owner2) = setup().await;
 
         // constructor(false, &deploy_wallet.contract, &Option::None(), 0).await;
@@ -68,7 +68,7 @@ mod reverts {
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
     #[ignore]
-    async fn panics_when_access_control_set_but_no_admin() {
+    async fn when_access_control_set_but_no_admin() {
         let (_deploy_wallet, _owner1, _owner2) = setup().await;
 
         // constructor(true, &deploy_wallet.contract, &Option::None(), 0).await;

--- a/NFT/tests/functions/meta_data.rs
+++ b/NFT/tests/functions/meta_data.rs
@@ -68,7 +68,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_token_does_not_exist() {
+    async fn when_token_does_not_exist() {
         let (_deploy_wallet, owner1, _owner2) = setup().await;
 
         meta_data(&owner1.contract, 1).await;

--- a/NFT/tests/functions/mint.rs
+++ b/NFT/tests/functions/mint.rs
@@ -123,7 +123,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_no_token_supply_set() {
+    async fn when_no_token_supply_set() {
         let (_deploy_wallet, owner1, _owner2) = setup().await;
 
         let minter = Identity::Address(owner1.wallet.address().into());
@@ -132,7 +132,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_minting_more_tokens_than_supply() {
+    async fn when_minting_more_tokens_than_supply() {
         let (deploy_wallet, owner1, _owner2) = setup().await;
 
         // constructor(false, &deploy_wallet.contract, &Option::None(), 1).await;
@@ -150,7 +150,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_minter_does_not_have_access() {
+    async fn when_minter_does_not_have_access() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 
         let minter = Identity::Address(owner2.wallet.address().into());

--- a/NFT/tests/functions/set_admin.rs
+++ b/NFT/tests/functions/set_admin.rs
@@ -36,7 +36,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_admin_not_set() {
+    async fn when_admin_not_set() {
         let (_deploy_wallet, owner1, _owner2) = setup().await;
 
         // let admin = Option::Some(Identity::Address(owner1.wallet.address().into()));
@@ -46,7 +46,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_not_admin_identity() {
+    async fn when_not_admin_identity() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 
         // let admin = Option::Some(Identity::Address(owner1.wallet.address().into()));

--- a/NFT/tests/functions/transfer_from.rs
+++ b/NFT/tests/functions/transfer_from.rs
@@ -151,7 +151,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_token_does_not_exist() {
+    async fn when_token_does_not_exist() {
         let (_deploy_wallet, owner1, owner2) = setup().await;
 
         let from = Identity::Address(owner1.wallet.address().into());
@@ -161,7 +161,7 @@ mod reverts {
 
     #[tokio::test]
     #[should_panic(expected = "Revert(42)")]
-    async fn panics_when_sender_is_not_owner_or_approved() {
+    async fn when_sender_is_not_owner_or_approved() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 
         // constructor(false, &deploy_wallet.contract, &Option::None(), 1).await;

--- a/dao-voting/tests/functions/constructor.rs
+++ b/dao-voting/tests/functions/constructor.rs
@@ -21,8 +21,8 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_when_reinitialized() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn when_reinitialized() {
         let (_gov_token, gov_token_id, deployer, _user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
         constructor(&deployer.dao_voting, gov_token_id).await;

--- a/dao-voting/tests/functions/create_proposal.rs
+++ b/dao-voting/tests/functions/create_proposal.rs
@@ -69,8 +69,8 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_when_duration_is_zero() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn when_duration_is_zero() {
         let (_gov_token, gov_token_id, deployer, _user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 
@@ -79,8 +79,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_with_zero_acceptance_percentage() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn with_zero_acceptance_percentage() {
         let (_gov_token, gov_token_id, deployer, _user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 
@@ -89,8 +89,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_with_over_hundred_acceptance_percentage() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn with_over_hundred_acceptance_percentage() {
         let (_gov_token, gov_token_id, deployer, _user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 

--- a/dao-voting/tests/functions/deposit.rs
+++ b/dao-voting/tests/functions/deposit.rs
@@ -54,8 +54,8 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_when_not_initialized() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn when_not_initialized() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 
         mint(
@@ -74,16 +74,16 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_with_incorrect_asset() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn with_incorrect_asset() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 
         let another_asset_id = Contract::deploy_with_parameters(
-            "./tests/artifacts/asset/out/debug/asset.bin",
+            "./tests/artifacts/gov_token/out/debug/gov_token.bin",
             &deployer.wallet,
             TxParameters::default(),
             StorageConfiguration::with_storage_path(Some(
-                "./tests/artifacts/asset/out/debug/gov_token-storage_slots.json".to_string(),
+                "./tests/artifacts/gov_token/out/debug/gov_token-storage_slots.json".to_string(),
             )),
             Salt::from([1u8; 32]),
         )
@@ -104,8 +104,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_zero_deposit() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_zero_deposit() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 
         mint(

--- a/dao-voting/tests/functions/execute.rs
+++ b/dao-voting/tests/functions/execute.rs
@@ -41,16 +41,16 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_invalid_proposal_id() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         execute(&user.dao_voting, 0).await;
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     #[ignore]
-    async fn panics_on_already_executed_proposal() {
+    async fn on_already_executed_proposal() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 
@@ -77,8 +77,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    pub async fn panics_on_active_proposal() {
+    #[should_panic(expected = "Revert(42)")]
+    pub async fn on_active_proposal() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 
@@ -104,8 +104,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    pub async fn panics_on_not_enough_yes_votes() {
+    #[should_panic(expected = "Revert(42)")]
+    pub async fn on_not_enough_yes_votes() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 

--- a/dao-voting/tests/functions/governance_token_id.rs
+++ b/dao-voting/tests/functions/governance_token_id.rs
@@ -21,8 +21,8 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    pub async fn panics_on_not_inialized() {
+    #[should_panic(expected = "Revert(42)")]
+    pub async fn on_not_inialized() {
         let (_gov_token, _gov_token_id, deployer, _user, _asset_amount) = setup().await;
         governance_token_id(&deployer.dao_voting).await;
     }

--- a/dao-voting/tests/functions/proposal.rs
+++ b/dao-voting/tests/functions/proposal.rs
@@ -34,8 +34,8 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_invalid_proposal_id() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         proposal(&user.dao_voting, 0).await;
     }

--- a/dao-voting/tests/functions/unlock_votes.rs
+++ b/dao-voting/tests/functions/unlock_votes.rs
@@ -214,15 +214,15 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_invalid_proposal_id() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         unlock_votes(&user.dao_voting, 0).await;
     }
 
     #[tokio::test]
-    #[should_panic]
-    pub async fn panics_on_active_proposal() {
+    #[should_panic(expected = "Revert(42)")]
+    pub async fn on_active_proposal() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 

--- a/dao-voting/tests/functions/user_votes.rs
+++ b/dao-voting/tests/functions/user_votes.rs
@@ -50,8 +50,8 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    pub async fn panics_on_invalid_proposal_id() {
+    #[should_panic(expected = "Revert(42)")]
+    pub async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         user_votes(&user.dao_voting, user.wallet.address(), 0).await;
     }

--- a/dao-voting/tests/functions/vote.rs
+++ b/dao-voting/tests/functions/vote.rs
@@ -121,15 +121,15 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_invalid_proposal_id() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         vote(&user.dao_voting, true, 0, 10).await;
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_zero_vote_amount() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_zero_vote_amount() {
         let (_gov_token, gov_token_id, deployer, user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 
@@ -139,8 +139,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_expired_proposal() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_expired_proposal() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 
@@ -164,8 +164,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_vote_amount_greater_than_balance() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_vote_amount_greater_than_balance() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 

--- a/dao-voting/tests/functions/withdraw.rs
+++ b/dao-voting/tests/functions/withdraw.rs
@@ -49,8 +49,8 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_withdraw_zero() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_withdraw_zero() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 
         mint(
@@ -72,8 +72,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_on_not_enough_assets() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn on_not_enough_assets() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 
         mint(

--- a/escrow/tests/functions/accept_arbiter.rs
+++ b/escrow/tests/functions/accept_arbiter.rs
@@ -117,7 +117,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -163,7 +163,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -208,7 +208,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_arbiter_proposal_is_not_set() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/tests/functions/create_escrow.rs
+++ b/escrow/tests/functions/create_escrow.rs
@@ -99,7 +99,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_assets_are_not_specified() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -131,7 +131,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_deadline_is_not_in_the_future() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -162,7 +162,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_arbiter_fee_is_zero() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(arbiter.wallet.address(), defaults.asset_id, 0).await;
@@ -188,7 +188,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_deposit_for_arbiter_fee_is_unequal() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -219,7 +219,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_asset_used_for_arbiter_fee_is_unequal() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -250,7 +250,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_arbiter_address_is_set_to_buyer() {
         let (_, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -281,7 +281,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_arbiter_address_is_set_to_seller() {
         let (_, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -312,7 +312,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_asset_amount_is_zero() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/tests/functions/deposit.rs
+++ b/escrow/tests/functions/deposit.rs
@@ -138,7 +138,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_deadline_is_reached() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -182,7 +182,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -234,7 +234,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -272,7 +272,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_depositing_more_than_once() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -323,7 +323,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_incorrect_asset_amount_is_sent() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -367,7 +367,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_incorrect_asset_is_sent() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/tests/functions/dispute.rs
+++ b/escrow/tests/functions/dispute.rs
@@ -123,7 +123,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -169,7 +169,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_disputing_more_than_once() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -215,7 +215,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -260,7 +260,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_buyer_has_not_deposited() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/tests/functions/propose_arbiter.rs
+++ b/escrow/tests/functions/propose_arbiter.rs
@@ -226,7 +226,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -272,7 +272,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_seller() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -291,7 +291,7 @@ mod revert {
         .await;
         mint(
             buyer.wallet.address(),
-            defaults.asset_amount,
+            defaults.asset_amount * 2,
             &defaults.asset,
         )
         .await;
@@ -317,7 +317,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_arbiter_address_is_set_to_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -368,7 +368,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_arbiter_address_is_set_to_seller() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -419,7 +419,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_arbiter_fee_is_zero() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -465,7 +465,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_deposit_for_arbiter_fee_is_unequal() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -525,7 +525,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_asset_used_for_arbiter_fee_is_unequal() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/tests/functions/resolve_dispute.rs
+++ b/escrow/tests/functions/resolve_dispute.rs
@@ -449,7 +449,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -510,7 +510,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_not_disputed() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -561,7 +561,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_arbiter() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -613,7 +613,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_user_is_not_buyer_or_seller() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -666,7 +666,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_buyer_has_not_deposited() {
         // Note: Buyer can only dispute after they deposit and we cannot get past the require
         //       checks in resolve_dispute unless there is a dispute therefore this cannot
@@ -674,7 +674,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_payment_amount_is_too_large() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/tests/functions/return_deposit.rs
+++ b/escrow/tests/functions/return_deposit.rs
@@ -199,7 +199,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -245,7 +245,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_seller() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -290,7 +290,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_buyer_has_not_deposited() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/tests/functions/take_payment.rs
+++ b/escrow/tests/functions/take_payment.rs
@@ -133,7 +133,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -179,7 +179,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_deadline_is_not_in_the_past() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -225,7 +225,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_disputed() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;
@@ -273,7 +273,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_seller() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;
@@ -320,7 +320,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_buyer_has_not_deposited() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;

--- a/escrow/tests/functions/transfer_to_seller.rs
+++ b/escrow/tests/functions/transfer_to_seller.rs
@@ -202,7 +202,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -248,7 +248,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_buyer_has_not_deposited() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -286,7 +286,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/tests/functions/withdraw_collateral.rs
+++ b/escrow/tests/functions/withdraw_collateral.rs
@@ -103,7 +103,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -149,7 +149,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_deadline_is_not_in_the_past() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -195,7 +195,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_caller_is_not_seller() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;
@@ -242,7 +242,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_buyer_has_deposited() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;

--- a/fundraiser/tests/functions/pledge.rs
+++ b/fundraiser/tests/functions/pledge.rs
@@ -378,6 +378,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
+    #[should_panic(expected = "Revert(42)")]
     async fn when_pledging_after_deadline() {
         let (author, user, asset, _, defaults) = setup().await;
         let deadline = 5;

--- a/oracle/tests/functions/set_price.rs
+++ b/oracle/tests/functions/set_price.rs
@@ -20,8 +20,8 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic]
-    async fn panics_when_not_owner() {
+    #[should_panic(expected = "Revert(42)")]
+    async fn when_not_owner() {
         let (user, wallets) = setup().await;
         user.oracle
             ._with_wallet(wallets[1].clone())


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Update all revert test function names to follow the `when_case` convention over the `panics_when_case` convention
- Add `#[should_panic(expected = "Revert(42)")]` to tests which did not have `expected = "Revert(42)"`
- Fixed test in dao-voting
     - In the `deposit::revert::with_incorrect_asset` test, the path to the gov_token folder was incorrect. Adding `expected = "Revert(42)"` highlighted this
- Fix test in escrow
     - In the `propose_arbiter::revert::when_caller_is_not_seller` test, the test was failing due to not having enough tokens, not the incorrect caller. Adding `expected = "Revert(42)"` highlighted this
- Add missing `should_panic` statement to fundraiser
     - Added to `pedge::revert::when_pledging_after_deadline`

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #221 
