### PR TITLE
Add a branch at the end of the build.sh script to crash if the project does not match the conditions above

### DIFF
--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -20,7 +20,7 @@ elif [ $PROJECT = 'multisig-wallet' ]; then
     forc build --path $PROJECT
 elif [ $PROJECT = 'NFT' ]; then
     forc build --path $PROJECT
-elif [ $PROJECT = 'oracle']; then
+elif [ $PROJECT = 'oracle' ]; then
     forc build --path $PROJECT
 else
     echo "project name did not match"

--- a/.github/scripts/build.sh
+++ b/.github/scripts/build.sh
@@ -22,4 +22,7 @@ elif [ $PROJECT = 'NFT' ]; then
     forc build --path $PROJECT
 elif [ $PROJECT = 'oracle']; then
     forc build --path $PROJECT
+else
+    echo "project name did not match"
+    exit 1
 fi


### PR DESCRIPTION
## Type of change

- Improvement

## Changes

The following changes have been made:

- Added an `else` condition at the end of the conditional branches, to fail if the project name is not matched in the conditions above

## Related Issues

Closes #236
