### PR TITLE
Removed github pages redirect content

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,38 +28,5 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.docs/contributing-book/book
-          destination_dir: live-book
+          destination_dir: book
         if: github.ref == 'refs/heads/master'
-
-      - name: Get tag
-        id: branch_name
-        run: |
-          echo ::set-output name=BRANCH_NAME::${GITHUB_REF#refs/tags/}
-        if: startsWith(github.ref, 'refs/tags')
-
-      - name: Deploy tag
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./.docs/contributing-book/book
-          destination_dir: ${{ steps.branch_name.outputs.BRANCH_NAME }}
-        if: startsWith(github.ref, 'refs/tags')
-
-      - name: Create latest HTML redirect file
-        if: startsWith(github.ref, 'refs/tags')
-        run: |
-          mkdir ./latest
-          cat > ./latest/index.html <<EOF
-          <!DOCTYPE html>
-          <meta charset="utf-8">
-          <meta http-equiv="refresh" content="0; URL=../${{ steps.branch_name.outputs.BRANCH_NAME }}/">
-          <link rel="canonical" href="../${{ steps.branch_name.outputs.BRANCH_NAME }}/">
-          EOF
-      
-      - name: Set latest to point to tag
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./latest/
-          destination_dir: ./latest/
-        if: startsWith(github.ref, 'refs/tags')


### PR DESCRIPTION
Only the live book will exist therefore the url should be set to `sway-applications/book/index.html`.
No need for all the version juggling since it won't be used. When it is needed it can be added by someone who is competent in devops (not me).