### PR TITLE
Update which branch the airdrop-distributor is using to build sway-libs

### DIFF
--- a/airdrop/airdrop-distributor/Forc.toml
+++ b/airdrop/airdrop-distributor/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "airdrop-distributor"
 
 [dependencies]
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", version = "0.1.0" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.1.0" }


### PR DESCRIPTION
## Type of change

- Bug fix

## Changes

The following changes have been made:

- Updates the target for the sway-libs dependency in the Forc.toml to use a tag as opposed to the version.

## Notes

- There should be a way to use libraries without the need to specify the git repository.

Closes #254 
