### PR TITLE
remove tilde from method calls for compatibility with the latest sway compiler

### DIFF
--- a/.docs/contributing-book/src/code/connect_four/src/main.sw
+++ b/.docs/contributing-book/src/code/connect_four/src/main.sw
@@ -8,7 +8,7 @@ use interface::ConnectFour;
 
 impl ConnectFour for Contract {
     fn create_game(player_one: Player, player_two: Player) -> Game {
-        ~Game::new(player_one, player_two)
+        Game::new(player_one, player_two)
     }
 
     fn move(column: u64, game: Game) -> Game {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   RUST_VERSION: 1.63.0
-  FORC_VERSION: 0.25.2
+  FORC_VERSION: 0.29.0
   CORE_VERSION: 0.10.1
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/NFT/src/main.sw
+++ b/NFT/src/main.sw
@@ -167,7 +167,7 @@ impl NFT for Contract {
         let mut index = tokens_minted;
         while index < total_mint {
             // Create the TokenMetaData for this new token
-            storage.meta_data.insert(index, ~TokenMetaData::new());
+            storage.meta_data.insert(index, TokenMetaData::new());
             storage.owners.insert(index, Option::Some(to));
             index += 1;
         }

--- a/airdrop/airdrop-distributor/src/main.sw
+++ b/airdrop/airdrop-distributor/src/main.sw
@@ -54,7 +54,7 @@ impl AirdropDistributor for Contract {
         require(verify_proof(key, leaf, storage.merkle_root.unwrap(), num_leaves, proof), VerificationError::MerkleProofFailed);
 
         // Mint asset
-        storage.claims.insert(to, ~ClaimData::new(amount, true));
+        storage.claims.insert(to, ClaimData::new(amount, true));
         mint_to(amount, storage.asset.unwrap(), to);
 
         log(ClaimEvent { to, amount });

--- a/auctions/english-auction/src/data_structures/token_asset.sw
+++ b/auctions/english-auction/src/data_structures/token_asset.sw
@@ -34,7 +34,7 @@ impl Asset for TokenAsset {
 impl core::ops::Add for TokenAsset {
     fn add(self, other: Self) -> Self {
         require(self.asset_id() == other.asset_id(), AssetError::AssetsAreNotTheSame);
-        ~TokenAsset::new(self.amount() + other.amount(), self.asset_id())
+        TokenAsset::new(self.amount() + other.amount(), self.asset_id())
     }
 }
 

--- a/auctions/english-auction/src/main.sw
+++ b/auctions/english-auction/src/main.sw
@@ -178,7 +178,7 @@ impl EnglishAuction for Contract {
         }
 
         // Setup auction
-        let auction = ~Auction::new(bid_asset, height() + duration, initial_price, reserve_price, sell_asset, seller);
+        let auction = Auction::new(bid_asset, height() + duration, initial_price, reserve_price, sell_asset, seller);
 
         // Store the auction information
         let total_auctions = storage.total_auctions;

--- a/dao-voting/src/main.sw
+++ b/dao-voting/src/main.sw
@@ -88,7 +88,7 @@ impl DaoVoting for Contract {
         require(0 < acceptance_percentage && acceptance_percentage <= 100, CreationError::InvalidAcceptancePercentage);
 
         let author = msg_sender().unwrap();
-        let proposal = ~ProposalInfo::new(acceptance_percentage, author, duration, proposal_transaction);
+        let proposal = ProposalInfo::new(acceptance_percentage, author, duration, proposal_transaction);
         storage.proposals.insert(storage.proposal_count, proposal);
         storage.proposal_count += 1;
 

--- a/escrow/src/main.sw
+++ b/escrow/src/main.sw
@@ -118,7 +118,7 @@ impl Escrow for Contract {
             index += 1;
         }
 
-        let escrow = ~EscrowInfo::new(arbiter, assets.len(), buyer, deadline, storage.assets.len() - assets.len(), msg_sender().unwrap());
+        let escrow = EscrowInfo::new(arbiter, assets.len(), buyer, deadline, storage.assets.len() - assets.len(), msg_sender().unwrap());
 
         storage.escrows.insert(storage.escrow_count, escrow);
 

--- a/multisig-wallet/src/main.sw
+++ b/multisig-wallet/src/main.sw
@@ -69,7 +69,7 @@ impl MultiSignatureWallet for Contract {
 
         let mut user_index = 0;
         while user_index < 25 {
-            require(~Address::from(ZERO_B256) != users[user_index].identity, InitError::AddressCannotBeZero);
+            require(Address::from(ZERO_B256) != users[user_index].identity, InitError::AddressCannotBeZero);
             require(users[user_index].weight != 0, InitError::WeightingCannotBeZero);
             storage.weighting.insert(users[user_index].identity, users[user_index].weight);
             user_index = user_index + 1;
@@ -197,7 +197,7 @@ fn create_hash(
 #[storage(read)]
 fn count_approvals(transaction_hash: b256, signatures: [B512; 25]) -> u64 {
     // The signers must have increasing values in order to check for duplicates or a zero-value
-    let mut previous_signer = ~b256::min();
+    let mut previous_signer = b256::min();
 
     let mut approval_count = 0;
     let mut index = 0;
@@ -210,7 +210,7 @@ fn count_approvals(transaction_hash: b256, signatures: [B512; 25]) -> u64 {
         require(previous_signer < signer, ExecutionError::IncorrectSignerOrdering);
 
         previous_signer = signer;
-        approval_count = approval_count + storage.weighting.get(~Address::from(signer));
+        approval_count = approval_count + storage.weighting.get(Address::from(signer));
 
         // Once break is implemented uncomment below. https://github.com/FuelLabs/sway/pull/1646
         // if storage.threshold <= approval_count {

--- a/oracle/src/main.sw
+++ b/oracle/src/main.sw
@@ -28,7 +28,7 @@ storage {
 // TODO treat owner as an identity once https://github.com/FuelLabs/sway/issues/2647 is fixed
 impl Oracle for Contract {
     fn owner() -> Identity {
-        Identity::Address(~Address::from(owner))
+        Identity::Address(Address::from(owner))
     }
 
     #[storage(read)]
@@ -38,7 +38,7 @@ impl Oracle for Contract {
 
     #[storage(write)]
     fn set_price(price: u64) {
-        require(msg_sender().unwrap() == Identity::Address(~Address::from(owner)), AccessError::NotOwner);
+        require(msg_sender().unwrap() == Identity::Address(Address::from(owner)), AccessError::NotOwner);
 
         storage.price = price;
 


### PR DESCRIPTION

## Type of change


- Other (describe below)

## Changes

The following changes have been made:

- Remove `~` from all method applications to be compatible with the latest version of Sway.

## Notes

Once https://github.com/FuelLabs/sway/pull/3218 goes in and `0.29.0` is released, code that contains `~`, like `~Address::from()`, will no longer compile. As a show of good faith, respect for our consumers, and in apology for breaking your repo, I'm submitting this PR. ❤️ 