### PR TITLE
Bump Airdrop-Distributor to use sway-libs v0.2.0

### DIFF
--- a/APPLICATION_PROGRESS.md
+++ b/APPLICATION_PROGRESS.md
@@ -39,7 +39,6 @@ The information in this section is split into subsections in order to conceptual
 <h3>Contracts ✅</h3>
 
 - Feature complete for UI integration
-  - Needs vec support in SDK so that array can be changed to vec
 
 <h3>User Interface</h3>
 

--- a/airdrop/airdrop-distributor/Cargo.toml
+++ b/airdrop/airdrop-distributor/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuel-merkle = { version = "0.3" }
+fuel-merkle = { version = "0.4.1" }
 fuels = { version = "0.25", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }

--- a/airdrop/airdrop-distributor/Forc.toml
+++ b/airdrop/airdrop-distributor/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "airdrop-distributor"
 
 [dependencies]
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.1.0" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.2.0" }

--- a/airdrop/airdrop-distributor/src/events.sw
+++ b/airdrop/airdrop-distributor/src/events.sw
@@ -1,7 +1,5 @@
 library events;
 
-use std::{contract_id::ContractId, identity::Identity};
-
 pub struct ClaimEvent {
     /// The quantity of an asset which is to be minted to the user.
     amount: u64,

--- a/airdrop/airdrop-distributor/src/interface.sw
+++ b/airdrop/airdrop-distributor/src/interface.sw
@@ -3,7 +3,6 @@ library interface;
 dep data_structures;
 
 use data_structures::ClaimData;
-use std::{contract_id::ContractId, identity::Identity};
 
 abi AirdropDistributor {
     /// This function will let users claim their airdrop.
@@ -26,7 +25,7 @@ abi AirdropDistributor {
     /// * When the `to` `Identity` has already claimed.
     /// * When the merkle proof verification failed.
     #[storage(read, write)]
-    fn claim(amount: u64, key: u64, num_leaves: u64, proof: [b256; 2], to: Identity, );
+    fn claim(amount: u64, key: u64, num_leaves: u64, proof: Vec<b256>, to: Identity);
 
     /// Returns the claim data stored on the given identity
     ///

--- a/airdrop/airdrop-distributor/src/main.sw
+++ b/airdrop/airdrop-distributor/src/main.sw
@@ -1,39 +1,29 @@
 contract;
 
-dep events;
-dep errors;
 dep data_structures;
+dep errors;
+dep events;
 dep interface;
 dep utils;
 
-use events::{ClaimEvent, CreateAirdropEvent};
-use errors::{AccessError, InitError, StateError, VerificationError};
 use data_structures::ClaimData;
+use errors::{AccessError, InitError, StateError, VerificationError};
+use events::{ClaimEvent, CreateAirdropEvent};
 use interface::AirdropDistributor;
-use std::{
-    address::Address,
-    block::height,
-    contract_id::ContractId,
-    hash::sha256,
-    identity::Identity,
-    logging::log,
-    option::Option,
-    revert::require,
-    storage::StorageMap,
-};
+use std::{block::height, hash::sha256, logging::log, storage::StorageMap};
 use sway_libs::binary_merkle_proof::{leaf_digest, verify_proof};
 use utils::mint_to;
 
 storage {
     /// The contract of the asset which is to be distributed.
-    asset: Option<ContractId> = Option::None(),
+    asset: Option<ContractId> = Option::None,
     /// Stores the ClaimData struct of users that have interacted with the Airdrop Distrubutor contract.
     /// Maps (user => claim)
     claims: StorageMap<Identity, ClaimData> = StorageMap {},
     /// The block at which the claiming period will end.
     end_block: u64 = 0,
     /// The computed merkle root which is to be verified against.
-    merkle_root: Option<b256> = Option::None(),
+    merkle_root: Option<b256> = Option::None,
 }
 
 impl AirdropDistributor for Contract {
@@ -42,7 +32,7 @@ impl AirdropDistributor for Contract {
         amount: u64,
         key: u64,
         num_leaves: u64,
-        proof: [b256; 2],
+        proof: Vec<b256>,
         to: Identity,
     ) {
         // The claiming period must be open and the `to` identity hasn't already claimed

--- a/airdrop/airdrop-distributor/src/utils.sw
+++ b/airdrop/airdrop-distributor/src/utils.sw
@@ -3,7 +3,6 @@ library utils;
 dep interface;
 
 use interface::SimpleAsset;
-use std::{contract_id::ContractId, identity::Identity};
 
 /// Calls the `mint_to` function in another contract.
 ///

--- a/airdrop/airdrop-distributor/tests/functions/claim.rs
+++ b/airdrop/airdrop-distributor/tests/functions/claim.rs
@@ -230,7 +230,7 @@ mod success {
         identity_vec.push(identity_a.clone());
         identity_vec.push(identity_b.clone());
         identity_vec.push(identity_c.clone());
-        
+
         let depth = 16;
         let airdrop_leaves = leaves_with_depth(depth, identity_vec.clone()).await;
         let num_leaves = airdrop_leaves.len().try_into().unwrap();

--- a/airdrop/airdrop-distributor/tests/functions/claim.rs
+++ b/airdrop/airdrop-distributor/tests/functions/claim.rs
@@ -1,9 +1,9 @@
 use crate::utils::{
     airdrop_distributor_abi_calls::{airdrop_constructor, claim, claim_data},
     simple_asset_abi_calls::asset_constructor,
-    test_helpers::{build_tree, build_tree_manual, defaults, setup},
+    test_helpers::{build_tree, build_tree_manual, defaults, leaves_with_depth, setup},
 };
-use fuels::tx::AssetId;
+use fuels::{prelude::Identity, tx::AssetId};
 
 mod success {
 
@@ -16,8 +16,18 @@ mod success {
     #[tokio::test]
     async fn claims() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time) =
-            defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
+        let (
+            identity_a,
+            _,
+            _,
+            minter,
+            key,
+            num_leaves,
+            asset_supply,
+            airdrop_leaves,
+            claim_time,
+            _,
+        ) = defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
         let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.to_vec()).await;
 
@@ -46,7 +56,7 @@ mod success {
         );
 
         claim(
-            airdrop_leaves[0].1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
@@ -62,7 +72,7 @@ mod success {
                 .get_asset_balance(&AssetId::new(*asset.asset_id))
                 .await
                 .unwrap(),
-            airdrop_leaves[0].1
+            airdrop_leaves[key as usize].1
         );
         assert_eq!(
             claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
@@ -75,10 +85,10 @@ mod success {
     #[tokio::test]
     async fn claims_manual_tree() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time) =
+        let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, depth) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (root, proof1, proof2) = build_tree_manual(airdrop_leaves.clone()).await;
+        let (_leaf, proof, root) = build_tree_manual(airdrop_leaves.clone(), depth, key).await;
 
         airdrop_constructor(
             asset.asset_id,
@@ -98,20 +108,23 @@ mod success {
             0
         );
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .claimed,
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
             false
         );
 
         claim(
-            airdrop_leaves[0].1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
-            [proof1, proof2],
-            identity_a.clone(),
+            proof.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
 
@@ -121,12 +134,161 @@ mod success {
                 .get_asset_balance(&AssetId::new(*asset.asset_id))
                 .await
                 .unwrap(),
-            airdrop_leaves[0].1
+            airdrop_leaves[key as usize].1
         );
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
+            true
+        );
+    }
+
+    #[tokio::test]
+    async fn claims_manual_tree_2_depth() {
+        let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
+        let (identity_a, identity_b, identity_c, minter, key, _, asset_supply, _, claim_time, _) =
+            defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
+
+        let mut identity_vec: Vec<Identity> = Vec::new();
+        identity_vec.push(identity_a.clone());
+        identity_vec.push(identity_b.clone());
+        identity_vec.push(identity_c.clone());
+
+        let depth = 2;
+        let airdrop_leaves = leaves_with_depth(depth, identity_vec.clone()).await;
+        let num_leaves = airdrop_leaves.len().try_into().unwrap();
+        let (_leaf, proof, root) = build_tree_manual(airdrop_leaves.clone(), depth, key).await;
+
+        airdrop_constructor(
+            asset.asset_id,
+            claim_time,
+            &deploy_wallet.airdrop_distributor,
+            root,
+        )
+        .await;
+        asset_constructor(asset_supply, &asset.asset, minter).await;
+
+        assert_eq!(
+            wallet1
+                .wallet
+                .get_asset_balance(&AssetId::new(*asset.asset_id))
                 .await
-                .claimed,
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
+            false
+        );
+
+        claim(
+            airdrop_leaves[key as usize].1,
+            asset.asset_id,
+            &deploy_wallet.airdrop_distributor,
+            key,
+            num_leaves,
+            proof.clone(),
+            airdrop_leaves[key as usize].0.clone(),
+        )
+        .await;
+
+        assert_eq!(
+            wallet1
+                .wallet
+                .get_asset_balance(&AssetId::new(*asset.asset_id))
+                .await
+                .unwrap(),
+            airdrop_leaves[key as usize].1
+        );
+        assert_eq!(
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
+            true
+        );
+    }
+
+    #[tokio::test]
+    async fn claims_manual_tree_16_depth() {
+        let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
+        let (identity_a, identity_b, identity_c, minter, key, _, asset_supply, _, claim_time, _) =
+            defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
+
+        let mut identity_vec: Vec<Identity> = Vec::new();
+        identity_vec.push(identity_a.clone());
+        identity_vec.push(identity_b.clone());
+        identity_vec.push(identity_c.clone());
+        
+        let depth = 16;
+        let airdrop_leaves = leaves_with_depth(depth, identity_vec.clone()).await;
+        let num_leaves = airdrop_leaves.len().try_into().unwrap();
+        let (_leaf, proof, root) = build_tree_manual(airdrop_leaves.clone(), depth, key).await;
+
+        airdrop_constructor(
+            asset.asset_id,
+            claim_time,
+            &deploy_wallet.airdrop_distributor,
+            root,
+        )
+        .await;
+        asset_constructor(asset_supply, &asset.asset, minter).await;
+
+        assert_eq!(
+            wallet1
+                .wallet
+                .get_asset_balance(&AssetId::new(*asset.asset_id))
+                .await
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
+            false
+        );
+
+        claim(
+            airdrop_leaves[key as usize].1,
+            asset.asset_id,
+            &deploy_wallet.airdrop_distributor,
+            key,
+            num_leaves,
+            proof.clone(),
+            airdrop_leaves[key as usize].0.clone(),
+        )
+        .await;
+
+        assert_eq!(
+            wallet1
+                .wallet
+                .get_asset_balance(&AssetId::new(*asset.asset_id))
+                .await
+                .unwrap(),
+            airdrop_leaves[key as usize].1
+        );
+        assert_eq!(
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
             true
         );
     }
@@ -140,22 +302,22 @@ mod revert {
     #[should_panic(expected = "Revert(42)")]
     async fn after_claim_period() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, _) =
+        let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, _, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.to_vec()).await;
+        let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.clone()).await;
 
         airdrop_constructor(asset.asset_id, 1, &deploy_wallet.airdrop_distributor, root).await;
         asset_constructor(asset_supply, &asset.asset, minter).await;
 
         claim(
-            1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
             proof.clone(),
-            identity_a.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
     }
@@ -168,10 +330,10 @@ mod revert {
     #[should_panic(expected = "Revert(42)")]
     async fn when_claim_twice() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time) =
+        let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.to_vec()).await;
+        let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.clone()).await;
 
         airdrop_constructor(
             asset.asset_id,
@@ -183,23 +345,24 @@ mod revert {
         asset_constructor(asset_supply, &asset.asset, minter).await;
 
         claim(
-            airdrop_leaves[0].1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
             proof.clone(),
-            identity_a.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
+
         claim(
-            airdrop_leaves[0].1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
             proof.clone(),
-            identity_a.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
     }
@@ -210,10 +373,10 @@ mod revert {
     #[should_panic(expected = "Revert(42)")]
     async fn when_claim_twice_manual_tree() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time) =
+        let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, depth) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (root, proof1, proof2) = build_tree_manual(airdrop_leaves.clone()).await;
+        let (_, proof, root) = build_tree_manual(airdrop_leaves.clone(), depth, key).await;
 
         airdrop_constructor(
             asset.asset_id,
@@ -234,13 +397,13 @@ mod revert {
         );
 
         claim(
-            airdrop_leaves[0].1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
-            [proof1, proof2],
-            identity_a.clone(),
+            proof.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
 
@@ -250,17 +413,17 @@ mod revert {
                 .get_asset_balance(&AssetId::new(*asset.asset_id))
                 .await
                 .unwrap(),
-            airdrop_leaves[0].1
+            airdrop_leaves[key as usize].1
         );
 
         claim(
-            1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
-            [proof1, proof2],
-            identity_a.clone(),
+            proof.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
     }
@@ -273,10 +436,10 @@ mod revert {
     #[should_panic(expected = "Revert(42)")]
     async fn when_failed_merkle_verification() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time) =
+        let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.to_vec()).await;
+        let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.clone()).await;
 
         airdrop_constructor(
             asset.asset_id,
@@ -295,7 +458,7 @@ mod revert {
             key,
             num_leaves,
             proof.clone(),
-            identity_a.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
     }
@@ -306,10 +469,10 @@ mod revert {
     #[should_panic(expected = "Revert(42)")]
     async fn when_failed_merkle_verification_manual_tree() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time) =
+        let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, depth) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (root, proof1, proof2) = build_tree_manual(airdrop_leaves.clone()).await;
+        let (_, proof, root) = build_tree_manual(airdrop_leaves.clone(), depth, key).await;
 
         airdrop_constructor(
             asset.asset_id,
@@ -327,8 +490,8 @@ mod revert {
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
-            [proof1, proof2],
-            identity_a.clone(),
+            proof.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
     }
@@ -337,19 +500,19 @@ mod revert {
     #[should_panic(expected = "Revert(42)")]
     async fn when_not_initalized() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, _minter, key, num_leaves, _, airdrop_leaves, _) =
+        let (_, _, _, _minter, key, num_leaves, _, airdrop_leaves, _, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (_tree, _root, _leaf, proof) = build_tree(key, airdrop_leaves.to_vec()).await;
+        let (_tree, _root, _leaf, proof) = build_tree(key, airdrop_leaves.clone()).await;
 
         claim(
-            airdrop_leaves[0].1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
             proof.clone(),
-            identity_a.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
     }

--- a/airdrop/airdrop-distributor/tests/functions/claim_data.rs
+++ b/airdrop/airdrop-distributor/tests/functions/claim_data.rs
@@ -15,10 +15,10 @@ mod success {
     #[tokio::test]
     async fn returns_claim_data() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time) =
+        let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.to_vec()).await;
+        let (_tree, root, _leaf, proof) = build_tree(key, airdrop_leaves.clone()).await;
 
         airdrop_constructor(
             asset.asset_id,
@@ -30,50 +30,62 @@ mod success {
         asset_constructor(asset_supply, &asset.asset, minter).await;
 
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .claimed,
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
             false
         );
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .amount,
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .amount,
             0
         );
 
         claim(
-            airdrop_leaves[0].1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
             proof.clone(),
-            identity_a.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
 
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .claimed,
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
             true
         );
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .amount,
-            airdrop_leaves[0].1
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .amount,
+            airdrop_leaves[key as usize].1
         );
     }
 
     #[tokio::test]
     async fn claims_manual_tree() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (identity_a, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time) =
+        let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, depth) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
 
-        let (root, proof1, proof2) = build_tree_manual(airdrop_leaves.clone()).await;
+        let (_, proof, root) = build_tree_manual(airdrop_leaves.clone(), depth, key).await;
 
         airdrop_constructor(
             asset.asset_id,
@@ -85,40 +97,52 @@ mod success {
         asset_constructor(asset_supply, &asset.asset, minter).await;
 
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .claimed,
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
             false
         );
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .amount,
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .amount,
             0
         );
 
         claim(
-            airdrop_leaves[0].1,
+            airdrop_leaves[key as usize].1,
             asset.asset_id,
             &deploy_wallet.airdrop_distributor,
             key,
             num_leaves,
-            [proof1, proof2],
-            identity_a.clone(),
+            proof.clone(),
+            airdrop_leaves[key as usize].0.clone(),
         )
         .await;
 
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .claimed,
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .claimed,
             true
         );
         assert_eq!(
-            claim_data(&deploy_wallet.airdrop_distributor, identity_a.clone())
-                .await
-                .amount,
-            airdrop_leaves[0].1
+            claim_data(
+                &deploy_wallet.airdrop_distributor,
+                airdrop_leaves[key as usize].0.clone()
+            )
+            .await
+            .amount,
+            airdrop_leaves[key as usize].1
         );
     }
 }

--- a/airdrop/airdrop-distributor/tests/functions/constructor.rs
+++ b/airdrop/airdrop-distributor/tests/functions/constructor.rs
@@ -11,7 +11,7 @@ mod success {
     #[tokio::test]
     async fn initalizes() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (_, _, _, _, _, _, _, _, claim_time) =
+        let (_, _, _, _, _, _, _, _, claim_time, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
         let provider = deploy_wallet.wallet.get_provider().unwrap();
         let root = Bits256([1u8; 32]);
@@ -42,7 +42,7 @@ mod revert {
     #[should_panic(expected = "Revert(42)")]
     async fn when_already_initalized() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (_, _, _, _, _, _, _, _, claim_time) =
+        let (_, _, _, _, _, _, _, _, claim_time, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
         let root = Bits256([1u8; 32]);
 

--- a/airdrop/airdrop-distributor/tests/functions/end_block.rs
+++ b/airdrop/airdrop-distributor/tests/functions/end_block.rs
@@ -11,7 +11,7 @@ mod success {
     #[tokio::test]
     async fn returns_end_block() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (_, _, _, _, _, _, _, _, claim_time) =
+        let (_, _, _, _, _, _, _, _, claim_time, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
         let provider = deploy_wallet.wallet.get_provider().unwrap();
         let root = Bits256([2u8; 32]);

--- a/airdrop/airdrop-distributor/tests/functions/merkle_root.rs
+++ b/airdrop/airdrop-distributor/tests/functions/merkle_root.rs
@@ -11,7 +11,7 @@ mod success {
     #[tokio::test]
     async fn returns_root() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
-        let (_, _, _, _, _, _, _, _, claim_time) =
+        let (_, _, _, _, _, _, _, _, claim_time, _) =
             defaults(&deploy_wallet, &wallet1, &wallet2, &wallet3).await;
         let root = Bits256([2u8; 32]);
 

--- a/airdrop/simple-asset/src/interface.sw
+++ b/airdrop/simple-asset/src/interface.sw
@@ -1,7 +1,5 @@
 library interface;
 
-use std::{contract_id::ContractId, identity::Identity};
-
 abi SimpleAsset {
     /// An example constructor which implements an airdrop distributor contract.
     ///

--- a/airdrop/simple-asset/src/main.sw
+++ b/airdrop/simple-asset/src/main.sw
@@ -10,11 +10,6 @@ use std::{
         AuthError,
         msg_sender,
     },
-    contract_id::ContractId,
-    identity::Identity,
-    option::Option,
-    result::Result,
-    revert::require,
     token::mint_to,
 };
 
@@ -24,7 +19,7 @@ storage {
     /// The maximum quantity of the asset ever to be minted.
     asset_supply: u64 = 0,
     /// The Address or Contract that has permission to mint.
-    minter: Option<Identity> = Option::None(),
+    minter: Option<Identity> = Option::None,
 }
 
 impl SimpleAsset for Contract {

--- a/airdrop/simple-asset/src/main.sw
+++ b/airdrop/simple-asset/src/main.sw
@@ -5,13 +5,7 @@ dep interface;
 
 use errors::{AccessError, InitError, InputError};
 use interface::SimpleAsset;
-use std::{
-    chain::auth::{
-        AuthError,
-        msg_sender,
-    },
-    token::mint_to,
-};
+use std::{chain::auth::{AuthError, msg_sender}, token::mint_to};
 
 storage {
     /// The current quantity of the asset minted.


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Sway-libs v0.2.0 uses a `Vec` in the merkle proof library over a fixed array. The airdrop has been updated to use this
- Updated tests to use `Vec` over a fixed array
- Added additional tests for different size Merkle proofs
- Cleaned up the airdrop-distributor for the newer version of forc
- Cleaned up the simple asset for the newer version of forc

## Notes

- The issue of `u8` padded to the size of a full word when packing into a tuple remains.

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #291 