### PR TITLE
Forc test change

### DIFF
--- a/.docs/contributing-book/src/documentation/project-quality/testing.md
+++ b/.docs/contributing-book/src/documentation/project-quality/testing.md
@@ -36,7 +36,7 @@ The repository follows the pattern of putting utility functions in `mod.rs` and 
 
 ### `harness.rs`
 
-This file is the entry point for the tests, and thus it contains only the modules `functions` and `utils`. This is what is executed when `cargo test` is run.
+The `harness` file is the entry point for the tests, and thus it contains the `functions` and `utils` modules. This is what is executed when `cargo test` is run.
 
 ## Testing Suggestions
 

--- a/.docs/contributing-book/src/documentation/project-quality/testing.md
+++ b/.docs/contributing-book/src/documentation/project-quality/testing.md
@@ -36,7 +36,7 @@ The repository follows the pattern of putting utility functions in `mod.rs` and 
 
 ### `harness.rs`
 
-This file is the one that is called by `forc test` and thus it only contains the modules `functions` and `utils` in order to bring them into scope so that the tests can run.
+This file is the one that is called by `forc build && cargo test` and thus it only contains the modules `functions` and `utils` in order to bring them into scope so that the tests can run.
 
 ## Testing Suggestions
 

--- a/.docs/contributing-book/src/documentation/project-quality/testing.md
+++ b/.docs/contributing-book/src/documentation/project-quality/testing.md
@@ -36,7 +36,7 @@ The repository follows the pattern of putting utility functions in `mod.rs` and 
 
 ### `harness.rs`
 
-This file is the one that is called by `forc build && cargo test` and thus it only contains the modules `functions` and `utils` in order to bring them into scope so that the tests can run.
+This file is the entry point for the tests, and thus it contains only the modules `functions` and `utils`. This is what is executed when `cargo test` is run.
 
 ## Testing Suggestions
 

--- a/NFT/README.md
+++ b/NFT/README.md
@@ -25,5 +25,6 @@ In order to run the tests make sure that you are in the root of this project i.e
 Run the tests
 
 ```bash
-forc test
+forc build
+cargo test
 ```

--- a/airdrop/README.md
+++ b/airdrop/README.md
@@ -51,7 +51,7 @@ In order to run the tests you will need to build both the simple-asset and airdr
 
 First, make sure that you are in the root of the simple-asset project i.e. `/path/to/airdrop/simple-asset/<you are here>`.
 
-There are two commands required to run the tests for simple-asset. This will build and test the simple-asset project.
+There are two commands required to run the tests for the simple-asset. The first command builds the contracts and the second command runs the tests.
 
 1. Run the tests
 

--- a/airdrop/README.md
+++ b/airdrop/README.md
@@ -56,7 +56,8 @@ There is one command required to run the tests for simple-asset. This will both 
 1. Run the tests
 
    ```bash
-   forc test
+   forc build
+cargo test
    ```
 
 Second, make sure that you are in the root of the airdrop-distributor project i.e. `/path/to/airdrop/airdrop-distributor/<you are here>`
@@ -66,7 +67,8 @@ As the simple-asset project has been compiled with the previous command, there i
 1. Run the tests
 
    ```bash
-   forc test
+   forc build
+cargo test
    ```
 
 ## Specification

--- a/airdrop/README.md
+++ b/airdrop/README.md
@@ -51,18 +51,7 @@ In order to run the tests you will need to build both the simple-asset and airdr
 
 First, make sure that you are in the root of the simple-asset project i.e. `/path/to/airdrop/simple-asset/<you are here>`.
 
-There is one command required to run the tests for simple-asset. This will both build and test the simple-asset project.
-
-1. Run the tests
-
-   ```bash
-   forc build
-   cargo test
-   ```
-
-Second, make sure that you are in the root of the airdrop-distributor project i.e. `/path/to/airdrop/airdrop-distributor/<you are here>`
-
-As the simple-asset project has been compiled with the previous command, there is one command required to run the tests for airdrop-distributor. This will both build and test the airdrop-distributor project.
+There are two commands required to run the tests for simple-asset. This will build and test the simple-asset project.
 
 1. Run the tests
 

--- a/airdrop/README.md
+++ b/airdrop/README.md
@@ -57,7 +57,7 @@ There is one command required to run the tests for simple-asset. This will both 
 
    ```bash
    forc build
-cargo test
+   cargo test
    ```
 
 Second, make sure that you are in the root of the airdrop-distributor project i.e. `/path/to/airdrop/airdrop-distributor/<you are here>`
@@ -68,7 +68,7 @@ As the simple-asset project has been compiled with the previous command, there i
 
    ```bash
    forc build
-cargo test
+   cargo test
    ```
 
 ## Specification

--- a/auctions/english-auction/README.md
+++ b/auctions/english-auction/README.md
@@ -55,7 +55,8 @@ There are three commands required to run the tests
 3. Run the tests
 
    ```bash
-   forc test
+   forc build
+cargo test
    ```
 
 ## Specification

--- a/auctions/english-auction/README.md
+++ b/auctions/english-auction/README.md
@@ -55,7 +55,6 @@ There are three commands required to run the tests
 3. Run the tests
 
    ```bash
-   forc build
    cargo test
    ```
 

--- a/auctions/english-auction/README.md
+++ b/auctions/english-auction/README.md
@@ -56,7 +56,7 @@ There are three commands required to run the tests
 
    ```bash
    forc build
-cargo test
+   cargo test
    ```
 
 ## Specification

--- a/dao-voting/README.md
+++ b/dao-voting/README.md
@@ -54,7 +54,6 @@ There are two commands required to run the tests
 2. Run the tests
 
    ```bash
-   forc build
    cargo test
    ```
 

--- a/dao-voting/README.md
+++ b/dao-voting/README.md
@@ -54,7 +54,8 @@ There are two commands required to run the tests
 2. Run the tests
 
    ```bash
-   forc test
+   forc build
+cargo test
    ```
 
 ## Specification

--- a/dao-voting/README.md
+++ b/dao-voting/README.md
@@ -55,7 +55,7 @@ There are two commands required to run the tests
 
    ```bash
    forc build
-cargo test
+   cargo test
    ```
 
 ## Specification

--- a/escrow/README.md
+++ b/escrow/README.md
@@ -52,7 +52,7 @@ There are two commands required to run the tests
 
    ```bash
    forc build
-cargo test
+   cargo test
    ```
 
 ## Specification

--- a/escrow/README.md
+++ b/escrow/README.md
@@ -51,7 +51,8 @@ There are two commands required to run the tests
 2. Run the tests
 
    ```bash
-   forc test
+   forc build
+cargo test
    ```
 
 ## Specification

--- a/escrow/README.md
+++ b/escrow/README.md
@@ -51,7 +51,6 @@ There are two commands required to run the tests
 2. Run the tests
 
    ```bash
-   forc build
    cargo test
    ```
 

--- a/fundraiser/README.md
+++ b/fundraiser/README.md
@@ -50,7 +50,7 @@ There are two commands required to run the tests
 
    ```bash
    forc build
-cargo test
+   cargo test
    ```
 
 ## Specification

--- a/fundraiser/README.md
+++ b/fundraiser/README.md
@@ -49,7 +49,8 @@ There are two commands required to run the tests
 2. Run the tests
 
    ```bash
-   forc test
+   forc build
+cargo test
    ```
 
 ## Specification

--- a/fundraiser/README.md
+++ b/fundraiser/README.md
@@ -49,7 +49,6 @@ There are two commands required to run the tests
 2. Run the tests
 
    ```bash
-   forc build
    cargo test
    ```
 

--- a/multisig-wallet/README.md
+++ b/multisig-wallet/README.md
@@ -50,7 +50,8 @@ Use the following command to run the tests
 1. Run the tests
 
    ```bash
-   forc test
+   forc build
+cargo test
    ```
 
 ## Specification

--- a/multisig-wallet/README.md
+++ b/multisig-wallet/README.md
@@ -50,7 +50,6 @@ Use the following command to run the tests
 1. Run the tests
 
    ```bash
-   forc build
    cargo test
    ```
 

--- a/multisig-wallet/README.md
+++ b/multisig-wallet/README.md
@@ -51,7 +51,7 @@ Use the following command to run the tests
 
    ```bash
    forc build
-cargo test
+   cargo test
    ```
 
 ## Specification


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Changed documentation for all instances of
```
forc test
```

to be

```
forc build
cargo test
```

Changes included `README.md`s and `.docs/contributing-book/src/documentation/project-quality/testing.md` (seen below)
```
This file is the one that is called by `forc build && cargo test` and thus it only contains the modules `functions` and `utils` in order to bring them into scope so that the tests can run.
```

## Notes


- There is still one mention of `forc test` in `.github\workflows\ci.yml`.
- Snippet of code:
```
      - name: Run Forc tests
        run: |
          cd ${{ matrix.project }}
          cargo test
```


## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #286
