### PR TITLE
Fundraiser paths mod

### DIFF
--- a/fundraiser/tests/utils/mod.rs
+++ b/fundraiser/tests/utils/mod.rs
@@ -24,6 +24,13 @@ pub struct MetaAsset {
     pub id: ContractId,
 }
 
+pub mod paths {
+    pub const CONTRACT_BINARY: &str = "./out/debug/fundraiser.bin";
+    pub const CONTRACT_STORAGE: &str = "./out/debug/fundraiser-storage_slots.json";
+    pub const ASSET_BINARY: &str = "./tests/artifacts/asset/out/debug/asset.bin";
+    pub const ASSET_STORAGE: &str = "./tests/artifacts/asset/out/debug/asset-storage_slots.json";
+}
+
 pub mod abi_calls {
 
     use super::*;
@@ -257,11 +264,4 @@ pub mod test_helpers {
 
         (author, user, asset, asset2, defaults)
     }
-}
-
-pub mod paths {
-    pub const CONTRACT_BINARY: &str = "./out/debug/fundraiser.bin";
-    pub const CONTRACT_STORAGE: &str = "./out/debug/fundraiser-storage_slots.json";
-    pub const ASSET_BINARY: &str = "./tests/artifacts/asset/out/debug/asset.bin";
-    pub const ASSET_STORAGE: &str = "./tests/artifacts/asset/out/debug/asset-storage_slots.json";
 }

--- a/fundraiser/tests/utils/mod.rs
+++ b/fundraiser/tests/utils/mod.rs
@@ -205,9 +205,7 @@ pub mod test_helpers {
             paths::CONTRACT_BINARY,
             &deployer_wallet,
             TxParameters::default(),
-            StorageConfiguration::with_storage_path(Some(
-                paths::CONTRACT_STORAGE.to_string(),
-            )),
+            StorageConfiguration::with_storage_path(Some(paths::CONTRACT_STORAGE.to_string())),
         )
         .await
         .unwrap();
@@ -216,9 +214,7 @@ pub mod test_helpers {
             paths::ASSET_BINARY,
             &deployer_wallet,
             TxParameters::default(),
-            StorageConfiguration::with_storage_path(Some(
-                paths::ASSET_STORAGE.to_string(),
-            )),
+            StorageConfiguration::with_storage_path(Some(paths::ASSET_STORAGE.to_string())),
         )
         .await
         .unwrap();
@@ -227,9 +223,7 @@ pub mod test_helpers {
             paths::ASSET_BINARY,
             &deployer_wallet,
             TxParameters::default(),
-            StorageConfiguration::with_storage_path(Some(
-                paths::ASSET_STORAGE.to_string(),
-            )),
+            StorageConfiguration::with_storage_path(Some(paths::ASSET_STORAGE.to_string())),
             Salt::from([1u8; 32]),
         )
         .await

--- a/fundraiser/tests/utils/mod.rs
+++ b/fundraiser/tests/utils/mod.rs
@@ -260,8 +260,8 @@ pub mod test_helpers {
 }
 
 pub mod paths {
-    const CONTRACT_BINARY: &str = "./out/debug/fundraiser.bin";
-    const CONTRACT_STORAGE: &str = "./out/debug/fundraiser-storage_slots.json";
-    const ASSET_BINARY: &str = "./tests/artifacts/asset/out/debug/asset.bin";
-    const ASSET_STORAGE: &str = "./tests/artifacts/asset/out/debug/asset-storage_slots.json";
+    pub const CONTRACT_BINARY: &str = "./out/debug/fundraiser.bin";
+    pub const CONTRACT_STORAGE: &str = "./out/debug/fundraiser-storage_slots.json";
+    pub const ASSET_BINARY: &str = "./tests/artifacts/asset/out/debug/asset.bin";
+    pub const ASSET_STORAGE: &str = "./tests/artifacts/asset/out/debug/asset-storage_slots.json";
 }

--- a/fundraiser/tests/utils/mod.rs
+++ b/fundraiser/tests/utils/mod.rs
@@ -258,3 +258,10 @@ pub mod test_helpers {
         (author, user, asset, asset2, defaults)
     }
 }
+
+pub mod paths {
+    const CONTRACT_BINARY: &str = "./out/debug/fundraiser.bin";
+    const CONTRACT_STORAGE: &str = "./out/debug/fundraiser-storage_slots.json";
+    const ASSET_BINARY: &str = "./tests/artifacts/asset/out/debug/asset.bin";
+    const ASSET_STORAGE: &str = "./tests/artifacts/asset/out/debug/asset-storage_slots.json";
+}

--- a/fundraiser/tests/utils/mod.rs
+++ b/fundraiser/tests/utils/mod.rs
@@ -195,33 +195,33 @@ pub mod test_helpers {
         let user_wallet = wallets.pop().unwrap();
 
         let id = Contract::deploy(
-            "./out/debug/fundraiser.bin",
+            paths::CONTRACT_BINARY,
             &deployer_wallet,
             TxParameters::default(),
             StorageConfiguration::with_storage_path(Some(
-                "./out/debug/fundraiser-storage_slots.json".to_string(),
+                paths::CONTRACT_STORAGE.to_string(),
             )),
         )
         .await
         .unwrap();
 
         let asset_id = Contract::deploy(
-            "./tests/artifacts/asset/out/debug/asset.bin",
+            paths::ASSET_BINARY,
             &deployer_wallet,
             TxParameters::default(),
             StorageConfiguration::with_storage_path(Some(
-                "./tests/artifacts/asset/out/debug/asset-storage_slots.json".to_string(),
+                paths::ASSET_STORAGE.to_string(),
             )),
         )
         .await
         .unwrap();
 
         let asset2_id = Contract::deploy_with_parameters(
-            "./tests/artifacts/asset/out/debug/asset.bin",
+            paths::ASSET_BINARY,
             &deployer_wallet,
             TxParameters::default(),
             StorageConfiguration::with_storage_path(Some(
-                "./tests/artifacts/asset/out/debug/asset-storage_slots.json".to_string(),
+                paths::ASSET_STORAGE.to_string(),
             )),
             Salt::from([1u8; 32]),
         )


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Created module in [mod.rs](https://github.com/FuelLabs/sway-applications/blob/690a0dd0e987a17a5ec3bc3740aa5c2d448bb6ab/fundraiser/tests/utils/mod.rs) 
- This module stores constants of type `&str` that hold paths for:

```
- CONTRACT_BINARY
- CONTRACT_STORAGE
- ASSET_BINARY
- ASSET_STORAGE
```
- Replaced string literals with newly created constants

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #278
