### PR TITLE
Escrow paths mod

### DIFF
--- a/escrow/tests/utils/mod.rs
+++ b/escrow/tests/utils/mod.rs
@@ -203,9 +203,7 @@ pub mod test_helpers {
             paths::ASSET_BINARY,
             &wallet,
             TxParameters::default(),
-            StorageConfiguration::with_storage_path(Some(
-                paths::ASSET_STORAGE.to_string(),
-            )),
+            StorageConfiguration::with_storage_path(Some(paths::ASSET_STORAGE.to_string())),
             Salt::from(salt),
         )
         .await
@@ -249,9 +247,7 @@ pub mod test_helpers {
             paths::CONTRACT_BINARY,
             &deployer_wallet,
             TxParameters::default(),
-            StorageConfiguration::with_storage_path(Some(
-                paths::CONTRACT_STORAGE.to_string(),
-            )),
+            StorageConfiguration::with_storage_path(Some(paths::CONTRACT_STORAGE.to_string())),
         )
         .await
         .unwrap();
@@ -260,9 +256,7 @@ pub mod test_helpers {
             paths::ASSET_BINARY,
             &deployer_wallet,
             TxParameters::default(),
-            StorageConfiguration::with_storage_path(Some(
-                paths::ASSET_STORAGE.to_string(),
-            )),
+            StorageConfiguration::with_storage_path(Some(paths::ASSET_STORAGE.to_string())),
         )
         .await
         .unwrap();

--- a/escrow/tests/utils/mod.rs
+++ b/escrow/tests/utils/mod.rs
@@ -15,6 +15,13 @@ pub struct User {
     pub wallet: WalletUnlocked,
 }
 
+pub mod paths {
+    pub const CONTRACT_BINARY: &str = "./out/debug/escrow.bin";
+    pub const CONTRACT_STORAGE: &str = "./out/debug/escrow-storage_slots.json";
+    pub const ASSET_BINARY: &str = "./tests/artifacts/asset/out/debug/asset.bin";
+    pub const ASSET_STORAGE: &str = "./tests/artifacts/asset/out/debug/asset-storage_slots.json";
+}
+
 pub mod abi_calls {
 
     use super::*;
@@ -193,11 +200,11 @@ pub mod test_helpers {
         wallet: WalletUnlocked,
     ) -> (ContractId, MyAsset) {
         let asset_id = Contract::deploy_with_parameters(
-            "./tests/artifacts/asset/out/debug/asset.bin",
+            paths::ASSET_BINARY,
             &wallet,
             TxParameters::default(),
             StorageConfiguration::with_storage_path(Some(
-                "./tests/artifacts/asset/out/debug/asset-storage_slots.json".to_string(),
+                paths::ASSET_STORAGE.to_string(),
             )),
             Salt::from(salt),
         )
@@ -239,22 +246,22 @@ pub mod test_helpers {
         let seller_wallet = wallets.pop().unwrap();
 
         let escrow_id = Contract::deploy(
-            "./out/debug/escrow.bin",
+            paths::CONTRACT_BINARY,
             &deployer_wallet,
             TxParameters::default(),
             StorageConfiguration::with_storage_path(Some(
-                "./out/debug/escrow-storage_slots.json".to_string(),
+                paths::CONTRACT_STORAGE.to_string(),
             )),
         )
         .await
         .unwrap();
 
         let asset_id = Contract::deploy(
-            "./tests/artifacts/asset/out/debug/asset.bin",
+            paths::ASSET_BINARY,
             &deployer_wallet,
             TxParameters::default(),
             StorageConfiguration::with_storage_path(Some(
-                "./tests/artifacts/asset/out/debug/asset-storage_slots.json".to_string(),
+                paths::ASSET_STORAGE.to_string(),
             )),
         )
         .await


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Created module in [mod.rs](https://github.com/FuelLabs/sway-applications/blob/089fa22ed13158144a5bc3c3915c60b68b254ea3/escrow/tests/utils/mod.rs) 
- This module stores constants of type `&str` that hold paths for:

```
- CONTRACT_BINARY
- CONTRACT_STORAGE
- ASSET_BINARY
- ASSET_STORAGE
```
- Replaced string literals with newly created constants

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #277
