### PR TITLE
AMM: Improve contracts and tests

### DIFF
--- a/AMM/project/contracts/AMM-contract/tests/functions/add_pool.rs
+++ b/AMM/project/contracts/AMM-contract/tests/functions/add_pool.rs
@@ -94,7 +94,7 @@ mod revert {
         let pair = asset_pairs[0];
 
         let invalid_exchange =
-            deploy_and_construct_exchange_contract(&wallet, pair, Option::Some(true), None).await;
+            deploy_and_construct_exchange_contract(&wallet, pair, Some(true), None).await;
 
         add_pool(&amm_instance, pair, invalid_exchange.contract_id).await;
     }

--- a/AMM/project/contracts/AMM-contract/tests/utils/mod.rs
+++ b/AMM/project/contracts/AMM-contract/tests/utils/mod.rs
@@ -9,7 +9,7 @@ abigen!(
     "./project/contracts/exchange-contract/out/debug/exchange-contract-abi.json"
 );
 
-pub struct MetaExchange {
+pub struct ExchangeContract {
     pub contract_id: ContractId,
     pub bytecode_root: ContractId,
 }
@@ -113,7 +113,7 @@ pub mod test_helpers {
         asset_pair: (ContractId, ContractId),
         malicious: Option<bool>,
         index_for_salt: Option<u8>,
-    ) -> MetaExchange {
+    ) -> ExchangeContract {
         let salt = [index_for_salt.unwrap_or(0u8); 32];
 
         let exchange_contract_id = Contract::deploy_with_parameters(
@@ -132,7 +132,7 @@ pub mod test_helpers {
 
         let exchange_instance = Exchange::new(exchange_contract_id.clone(), wallet.clone());
         constructor(&exchange_instance, asset_pair).await;
-        MetaExchange {
+        ExchangeContract {
             contract_id: ContractId::new(*exchange_contract_id.hash()),
             bytecode_root: bytecode_root().await,
         }

--- a/AMM/project/contracts/exchange-contract/src/main.sw
+++ b/AMM/project/contracts/exchange-contract/src/main.sw
@@ -39,6 +39,7 @@ use std::{
     },
 };
 use utils::{
+    determine_output_asset,
     div_multiply,
     maximum_input_for_exact_output,
     minimum_output_given_exact_input,
@@ -224,31 +225,26 @@ impl Exchange for Contract {
 
     #[storage(read, write)]
     fn swap_exact_input(min_output: Option<u64>, deadline: u64) -> u64 {
-        require(storage.pair.is_some(), InitError::NotInitialized);
-
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
         let input_asset = msg_asset_id();
+        let output_asset = determine_output_asset(input_asset, storage.pair);
 
-        require(input_asset == asset_a_id || input_asset == asset_b_id, InputError::InvalidAsset);
         require(deadline >= height(), InputError::DeadlinePassed);
 
         let exact_input = msg_amount();
         require(exact_input > 0, InputError::AmountCannotBeZero);
 
         let sender = msg_sender().unwrap();
-        let output_asset = if input_asset == asset_a_id {
-            asset_b_id
-        } else {
-            asset_a_id
-        };
         let input_asset_in_reserve = storage.reserves.get(input_asset);
         let output_asset_in_reserve = storage.reserves.get(output_asset);
 
         let bought = minimum_output_given_exact_input(exact_input, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
+
         require(bought <= output_asset_in_reserve, TransactionError::InsufficientLiquidity);
+
         if min_output.is_some() {
             require(bought >= min_output.unwrap(), TransactionError::DesiredAmountTooHigh(min_output.unwrap()));
         }
+
         transfer(bought, output_asset, sender);
         storage.reserves.insert(input_asset, input_asset_in_reserve + exact_input);
         storage.reserves.insert(output_asset, output_asset_in_reserve - bought);
@@ -265,12 +261,9 @@ impl Exchange for Contract {
 
     #[storage(read, write)]
     fn swap_exact_output(output: u64, deadline: u64) -> u64 {
-        require(storage.pair.is_some(), InitError::NotInitialized);
-
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
         let input_asset = msg_asset_id();
+        let output_asset = determine_output_asset(input_asset, storage.pair);
 
-        require(input_asset == asset_a_id || input_asset == asset_b_id, InputError::InvalidAsset);
         require(deadline > height(), InputError::DeadlinePassed);
         require(output > 0, InputError::AmountCannotBeZero);
 
@@ -278,11 +271,6 @@ impl Exchange for Contract {
         require(input_amount > 0, InputError::AmountCannotBeZero);
 
         let sender = msg_sender().unwrap();
-        let output_asset = if input_asset == asset_a_id {
-            asset_b_id
-        } else {
-            asset_a_id
-        };
         let input_asset_in_reserve = storage.reserves.get(input_asset);
         let output_asset_in_reserve = storage.reserves.get(output_asset);
 
@@ -296,6 +284,7 @@ impl Exchange for Contract {
         if refund > 0 {
             transfer(refund, input_asset, sender);
         };
+
         transfer(output, output_asset, sender);
         storage.reserves.insert(input_asset, input_asset_in_reserve + sold);
         storage.reserves.insert(output_asset, output_asset_in_reserve - output);
@@ -401,17 +390,8 @@ impl Exchange for Contract {
 
     #[storage(read)]
     fn preview_swap_exact_input(exact_input: u64, input_asset: ContractId) -> PreviewSwapInfo {
-        require(storage.pair.is_some(), InitError::NotInitialized);
+        let output_asset = determine_output_asset(input_asset, storage.pair);
 
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
-
-        require(input_asset == asset_a_id || input_asset == asset_b_id, InputError::InvalidAsset);
-
-        let output_asset = if input_asset == asset_a_id {
-            asset_b_id
-        } else {
-            asset_a_id
-        };
         let input_asset_in_reserve = storage.reserves.get(input_asset);
         let output_asset_in_reserve = storage.reserves.get(output_asset);
 
@@ -437,8 +417,10 @@ impl Exchange for Contract {
         } else {
             asset_a_id
         };
+
         let input_asset_in_reserve = storage.reserves.get(input_asset);
         let output_asset_in_reserve = storage.reserves.get(output_asset);
+
         require(exact_output <= output_asset_in_reserve, TransactionError::DesiredAmountTooHigh(exact_output));
 
         let max_input = maximum_input_for_exact_output(exact_output, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);

--- a/AMM/project/contracts/exchange-contract/src/main.sw
+++ b/AMM/project/contracts/exchange-contract/src/main.sw
@@ -40,8 +40,8 @@ use std::{
 };
 use utils::{
     div_multiply,
-    get_maximum_input_for_exact_output,
-    get_minimum_output_given_exact_input,
+    maximum_input_for_exact_output,
+    minimum_output_given_exact_input,
     multiply_div,
 };
 
@@ -243,7 +243,8 @@ impl Exchange for Contract {
         };
         let input_asset_in_reserve = storage.reserves.get(input_asset);
         let output_asset_in_reserve = storage.reserves.get(output_asset);
-        let bought = get_minimum_output_given_exact_input(exact_input, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
+
+        let bought = minimum_output_given_exact_input(exact_input, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
         require(bought <= output_asset_in_reserve, TransactionError::InsufficientLiquidity);
         if min_output.is_some() {
             require(bought >= min_output.unwrap(), TransactionError::DesiredAmountTooHigh(min_output.unwrap()));
@@ -287,7 +288,7 @@ impl Exchange for Contract {
 
         require(output <= output_asset_in_reserve, TransactionError::InsufficientLiquidity);
 
-        let sold = get_maximum_input_for_exact_output(output, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
+        let sold = maximum_input_for_exact_output(output, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
 
         require(input_amount >= sold, TransactionError::ProvidedAmountTooLow(input_amount));
 
@@ -413,7 +414,8 @@ impl Exchange for Contract {
         };
         let input_asset_in_reserve = storage.reserves.get(input_asset);
         let output_asset_in_reserve = storage.reserves.get(output_asset);
-        let min_output = get_minimum_output_given_exact_input(exact_input, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
+
+        let min_output = minimum_output_given_exact_input(exact_input, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
         let sufficient_reserve = min_output <= output_asset_in_reserve;
 
         PreviewSwapInfo {
@@ -438,7 +440,8 @@ impl Exchange for Contract {
         let input_asset_in_reserve = storage.reserves.get(input_asset);
         let output_asset_in_reserve = storage.reserves.get(output_asset);
         require(exact_output <= output_asset_in_reserve, TransactionError::DesiredAmountTooHigh(exact_output));
-        let max_input = get_maximum_input_for_exact_output(exact_output, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
+
+        let max_input = maximum_input_for_exact_output(exact_output, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
         let sufficient_reserve = exact_output <= output_asset_in_reserve;
 
         PreviewSwapInfo {

--- a/AMM/project/contracts/exchange-contract/src/utils.sw
+++ b/AMM/project/contracts/exchange-contract/src/utils.sw
@@ -1,6 +1,9 @@
 library utils;
 
+dep errors;
+
 use core::num::*;
+use errors::{InitError, InputError};
 use std::u128::U128;
 
 fn calculate_amount_with_fee(amount: u64, liquidity_miner_fee: u64) -> u64 {
@@ -55,4 +58,18 @@ pub fn multiply_div(a: u64, b: u64, c: u64) -> u64 {
     let calculation = (U128::from((0, a)) * U128::from((0, b)));
     let result_wrapped = (calculation / U128::from((0, c))).as_u64();
     result_wrapped.unwrap()
+}
+
+pub fn determine_output_asset(
+    input_asset: ContractId,
+    pair: Option<(ContractId, ContractId)>,
+) -> ContractId {
+    require(pair.is_some(), InitError::NotInitialized);
+    let (asset_a_id, asset_b_id) = pair.unwrap();
+    require(input_asset == asset_a_id || input_asset == asset_b_id, InputError::InvalidAsset);
+    if input_asset == asset_a_id {
+        asset_b_id
+    } else {
+        asset_a_id
+    }
 }

--- a/AMM/project/contracts/exchange-contract/src/utils.sw
+++ b/AMM/project/contracts/exchange-contract/src/utils.sw
@@ -15,7 +15,7 @@ pub fn div_multiply(a: u64, b: u64, c: u64) -> u64 {
 }
 
 /// Returns the maximum required amount of the input asset to get exactly ` output_amount ` of the output asset
-pub fn get_maximum_input_for_exact_output(
+pub fn maximum_input_for_exact_output(
     output_amount: u64,
     input_reserve: u64,
     output_reserve: u64,
@@ -37,7 +37,7 @@ pub fn get_maximum_input_for_exact_output(
 }
 
 /// Given exactly ` input_amount ` of the input asset, returns the minimum resulting amount of the output asset
-pub fn get_minimum_output_given_exact_input(
+pub fn minimum_output_given_exact_input(
     input_amount: u64,
     input_reserve: u64,
     output_reserve: u64,

--- a/AMM/project/contracts/exchange-contract/tests/functions/add_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/add_liquidity.rs
@@ -5,7 +5,7 @@ use crate::utils::{
         setup_and_initialize, setup_initialize_and_deposit_but_do_not_add_liquidity,
         setup_initialize_deposit_and_add_liquidity, wallet_balances,
     },
-    MetaAmounts,
+    LiquidityParameters,
 };
 use fuels::prelude::*;
 
@@ -74,7 +74,7 @@ mod success {
     #[tokio::test]
     async fn adds_when_liquidity_exists_based_on_a_and_refunds() {
         let (exchange, wallet, amounts, _asset_c_id) = setup_and_initialize().await;
-        let second_liquidity_amounts = MetaAmounts {
+        let second_liquidity_amounts = LiquidityParameters {
             amount_a: amounts.amount_a,
             amount_b: amounts.amount_b * 2,
             deadline: amounts.deadline,
@@ -144,7 +144,7 @@ mod success {
     #[tokio::test]
     async fn adds_when_liquidity_exists_based_on_b_and_refunds() {
         let (exchange, wallet, amounts, _asset_c_id) = setup_and_initialize().await;
-        let second_liquidity_amounts = MetaAmounts {
+        let second_liquidity_amounts = LiquidityParameters {
             amount_a: amounts.amount_a * 2,
             amount_b: amounts.amount_b,
             deadline: amounts.deadline,
@@ -238,7 +238,7 @@ mod revert {
     async fn when_deadline_has_passed() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: amounts.amount_a,
             amount_b: amounts.amount_b,
             deadline: 0, // deadline too low
@@ -274,7 +274,7 @@ mod revert {
     async fn when_desired_liquidity_is_less_than_minimum_liquidity() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: amounts.amount_a,
             amount_b: amounts.amount_b,
             deadline: amounts.deadline,
@@ -289,7 +289,7 @@ mod revert {
     async fn when_deposited_a_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: 0, // depositing 0 amount of asset A
             amount_b: amounts.amount_b,
             deadline: amounts.deadline,
@@ -304,7 +304,7 @@ mod revert {
     async fn when_deposited_b_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: amounts.amount_a,
             amount_b: 0, // depositing 0 amount of asset B
             deadline: amounts.deadline,
@@ -319,7 +319,7 @@ mod revert {
     async fn when_liquidity_is_zero_but_desired_liquidity_is_too_high() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: amounts.amount_a,
             amount_b: amounts.amount_b,
             deadline: amounts.deadline,
@@ -335,7 +335,7 @@ mod revert {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: amounts.amount_a,
             amount_b: amounts.amount_b * 2, // setting this so that liquidity is calculated based on asset A amount
             deadline: amounts.deadline,
@@ -351,7 +351,7 @@ mod revert {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: amounts.amount_a * 2, // setting this so that liquidity is calculated based on asset B amount
             amount_b: amounts.amount_b,
             deadline: amounts.deadline,

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_add_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_add_liquidity.rs
@@ -72,11 +72,7 @@ mod success {
         let preview = preview_add_liquidity(
             &exchange.instance,
             CallParameters::default(),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
+            TxParameters::new(None, Some(100_000_000), None),
             preview_amount_a,
             exchange.asset_a,
         )
@@ -111,11 +107,7 @@ mod success {
         let preview = preview_add_liquidity(
             &exchange.instance,
             CallParameters::default(),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
+            TxParameters::new(None, Some(100_000_000), None),
             preview_amount_a,
             exchange.asset_a,
         )
@@ -150,11 +142,7 @@ mod success {
         let preview = preview_add_liquidity(
             &exchange.instance,
             CallParameters::default(),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
+            TxParameters::new(None, Some(100_000_000), None),
             preview_amount_b,
             exchange.asset_b,
         )
@@ -189,11 +177,7 @@ mod success {
         let preview = preview_add_liquidity(
             &exchange.instance,
             CallParameters::default(),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
+            TxParameters::new(None, Some(100_000_000), None),
             preview_amount_b,
             exchange.asset_b,
         )

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_add_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_add_liquidity.rs
@@ -4,7 +4,7 @@ use crate::utils::{
         deposit_and_add_liquidity, setup, setup_and_initialize,
         setup_initialize_deposit_and_add_liquidity,
     },
-    MetaAmounts,
+    LiquidityParameters,
 };
 use fuels::prelude::*;
 
@@ -90,7 +90,7 @@ mod success {
     async fn previews_adding_a_when_liquidity_is_not_zero_based_on_b() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: 400,
             amount_b: 100,
             deadline: amounts.deadline,
@@ -125,7 +125,7 @@ mod success {
     async fn previews_adding_b_when_liquidity_is_not_zero_based_on_a() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: 400,
             amount_b: 100,
             deadline: amounts.deadline,
@@ -160,7 +160,7 @@ mod success {
     async fn previews_adding_b_when_liquidity_is_not_zero_based_on_b() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
-        let override_amounts = MetaAmounts {
+        let override_amounts = LiquidityParameters {
             amount_a: 400,
             amount_b: 100,
             deadline: amounts.deadline,

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_input.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_input.rs
@@ -7,7 +7,7 @@ mod success {
     use super::*;
 
     #[tokio::test]
-    async fn previews_partial_swap_of_a() {
+    async fn previews_swap_of_a() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
         let input_amount = 10;
@@ -30,7 +30,7 @@ mod success {
     }
 
     #[tokio::test]
-    async fn previews_partial_swap_of_b() {
+    async fn previews_swap_of_b() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
         let input_amount = 10;

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_output.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_output.rs
@@ -7,7 +7,7 @@ mod success {
     use super::*;
 
     #[tokio::test]
-    async fn previews_partial_swap_of_a() {
+    async fn previews_swap_of_a() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
 
@@ -33,7 +33,7 @@ mod success {
     }
 
     #[tokio::test]
-    async fn previews_partial_swap_of_b() {
+    async fn previews_swap_of_b() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
 

--- a/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
@@ -29,13 +29,8 @@ mod success {
             CallParameters::new(
                 Some(liquidity_to_remove),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             amounts.deadline,
@@ -95,13 +90,8 @@ mod success {
             CallParameters::new(
                 Some(liquidity_to_remove),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             amounts.deadline,
@@ -161,13 +151,8 @@ mod success {
             CallParameters::new(
                 Some(liquidity_to_remove),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             amounts.deadline,
@@ -227,13 +212,8 @@ mod success {
             CallParameters::new(
                 Some(liquidity_to_remove),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             amounts.deadline,
@@ -296,13 +276,8 @@ mod revert {
                 // Normally, this also causes Revert(18446744073709486080),
                 // but this test condition (not initialized contract) reverts before that.
                 None,
-                Some(10_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 10_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             deadline,
@@ -325,13 +300,8 @@ mod revert {
                 Some(amounts.liquidity),
                 // sending an asset other than pool asset
                 Some(exchange.asset_a),
-                Some(10_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 10_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             amounts.deadline,
@@ -352,13 +322,8 @@ mod revert {
             CallParameters::new(
                 Some(amounts.liquidity),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             // passing 0 as min_asset_a
             0,
             b_to_remove,
@@ -380,13 +345,8 @@ mod revert {
             CallParameters::new(
                 Some(amounts.liquidity),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             // passing 0 as min_asset_b
             0,
@@ -409,13 +369,8 @@ mod revert {
             CallParameters::new(
                 Some(amounts.liquidity),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             // passing 0 as deadline
@@ -439,13 +394,8 @@ mod revert {
                 // sending 0 msg_amount
                 Some(0),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             amounts.deadline,
@@ -470,13 +420,8 @@ mod revert {
                 // Normally, this also causes Revert(18446744073709486080),
                 // but this test condition (zero liquidity) reverts before that.
                 None,
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             b_to_remove,
             amounts.deadline,
@@ -502,13 +447,8 @@ mod revert {
             CallParameters::new(
                 Some(amounts.liquidity),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             // setting min_asset_a to be higher than what can be removed
             asset_a_amount_to_remove + 10,
             b_to_remove,
@@ -535,13 +475,8 @@ mod revert {
             CallParameters::new(
                 Some(amounts.liquidity),
                 Some(exchange.liquidity_pool_asset),
-                Some(100_000_000),
+                None,
             ),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
             a_to_remove,
             // setting min_asset_b to be higher than what can be removed
             asset_b_amount_to_remove + 10,

--- a/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_input.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_input.rs
@@ -25,7 +25,7 @@ mod success {
 
         let output_amount = swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(input_amount), Some(exchange.asset_a), Some(10_000_000)),
+            CallParameters::new(Some(input_amount), Some(exchange.asset_a), None),
             Some(min_output),
             amounts.deadline,
         )
@@ -72,7 +72,7 @@ mod success {
 
         let output_amount = swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(input_amount), Some(exchange.asset_b), Some(10_000_000)),
+            CallParameters::new(Some(input_amount), Some(exchange.asset_b), None),
             Some(min_output),
             amounts.deadline,
         )
@@ -113,7 +113,7 @@ mod success {
 
         let output_amount = swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(input_amount), Some(exchange.asset_a), Some(10_000_000)),
+            CallParameters::new(Some(input_amount), Some(exchange.asset_a), None),
             None,
             amounts.deadline,
         )
@@ -156,7 +156,7 @@ mod revert {
 
         swap_exact_input(
             &exchange_instance,
-            CallParameters::new(Some(1), Some(AssetId::new(*asset_a_id)), Some(10_000_000)),
+            CallParameters::new(Some(1), Some(AssetId::new(*asset_a_id)), None),
             None,
             deadline,
         )
@@ -172,7 +172,7 @@ mod revert {
         swap_exact_input(
             &exchange.instance,
             // sending invalid asset
-            CallParameters::new(Some(1), Some(AssetId::new(*asset_c_id)), Some(10_000_000)),
+            CallParameters::new(Some(1), Some(AssetId::new(*asset_c_id)), None),
             None,
             amounts.deadline,
         )
@@ -187,7 +187,7 @@ mod revert {
 
         swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(1), Some(exchange.asset_a), Some(10_000_000)),
+            CallParameters::new(Some(1), Some(exchange.asset_a), None),
             None,
             // passing 0 deadline
             0,
@@ -204,7 +204,7 @@ mod revert {
         swap_exact_input(
             &exchange.instance,
             // forwarding 0 as msg_amount
-            CallParameters::new(Some(0), Some(exchange.asset_a), Some(10_000_000)),
+            CallParameters::new(Some(0), Some(exchange.asset_a), None),
             None,
             amounts.deadline,
         )
@@ -227,7 +227,7 @@ mod revert {
 
         swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(input_amount), Some(exchange.asset_a), Some(10_000_000)),
+            CallParameters::new(Some(input_amount), Some(exchange.asset_a), None),
             // setting min too high
             Some(preview_amount + 1),
             amounts.deadline,

--- a/AMM/project/contracts/exchange-contract/tests/utils/mod.rs
+++ b/AMM/project/contracts/exchange-contract/tests/utils/mod.rs
@@ -48,6 +48,9 @@ pub mod abi_calls {
             .methods()
             .add_liquidity(desired_liquidity, deadline)
             .call_params(call_params)
+            // `add_liquidity` adds liquidity by using up at least one of the assets
+            // one variable output is for the minted liquidity pool asset
+            // the other variable output is for the asset that is not used up
             .append_variable_outputs(2)
             .tx_params(tx_params)
             .call()
@@ -108,7 +111,7 @@ pub mod abi_calls {
                 gas_limit: 10_000_000,
                 maturity: 0,
             })
-            .append_variable_outputs(2)
+            .append_variable_outputs(1)
             .call()
             .await
             .unwrap()

--- a/AMM/project/contracts/exchange-contract/tests/utils/mod.rs
+++ b/AMM/project/contracts/exchange-contract/tests/utils/mod.rs
@@ -80,7 +80,6 @@ pub mod abi_calls {
     pub async fn remove_liquidity(
         contract: &Exchange,
         call_params: CallParameters,
-        tx_params: TxParameters,
         min_asset_a: u64,
         min_asset_b: u64,
         deadline: u64,
@@ -89,7 +88,7 @@ pub mod abi_calls {
             .methods()
             .remove_liquidity(min_asset_a, min_asset_b, deadline)
             .call_params(call_params)
-            .tx_params(tx_params)
+            .tx_params(TxParameters::new(None, Some(10_000_000), None))
             .append_variable_outputs(2)
             .call()
             .await
@@ -106,11 +105,7 @@ pub mod abi_calls {
             .methods()
             .swap_exact_input(min_output, deadline)
             .call_params(call_params)
-            .tx_params(TxParameters {
-                gas_price: 0,
-                gas_limit: 10_000_000,
-                maturity: 0,
-            })
+            .tx_params(TxParameters::new(None, Some(10_000_000), None))
             .append_variable_outputs(1)
             .call()
             .await
@@ -127,11 +122,7 @@ pub mod abi_calls {
             .methods()
             .swap_exact_output(output, deadline)
             .call_params(call_params)
-            .tx_params(TxParameters {
-                gas_price: 0,
-                gas_limit: 10_000_000,
-                maturity: 0,
-            })
+            .tx_params(TxParameters::new(None, Some(10_000_000), None))
             .append_variable_outputs(2)
             .call()
             .await
@@ -186,11 +177,7 @@ pub mod abi_calls {
         contract
             .methods()
             .preview_swap_exact_input(exact_input, ContractId::new(*input_asset))
-            .tx_params(TxParameters {
-                gas_price: 0,
-                gas_limit: 10_000_000,
-                maturity: 0,
-            })
+            .tx_params(TxParameters::new(None, Some(10_000_000), None))
             .call()
             .await
             .unwrap()
@@ -204,11 +191,7 @@ pub mod abi_calls {
         contract
             .methods()
             .preview_swap_exact_output(exact_output, ContractId::new(*output_asset))
-            .tx_params(TxParameters {
-                gas_price: 0,
-                gas_limit: 10_000_000,
-                maturity: 0,
-            })
+            .tx_params(TxParameters::new(None, Some(10_000_000), None))
             .call()
             .await
             .unwrap()
@@ -262,12 +245,8 @@ pub mod test_helpers {
 
         let added = add_liquidity(
             &exchange.instance,
-            CallParameters::new(Some(0), None, Some(100_000_000)),
-            TxParameters {
-                gas_price: 0,
-                gas_limit: 100_000_000,
-                maturity: 0,
-            },
+            CallParameters::new(Some(0), None, None),
+            TxParameters::new(None, Some(100_000_000), None),
             amounts.liquidity,
             amounts.deadline,
         )


### PR DESCRIPTION
## Type of change

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- `get` prefixes have been removed from contract utility functions
- `determine_output_asset` utility function has been added to the exchange contract to keep the code DRY
- The number of variable outputs appended to a function call has been corrected
- `TxParameters` have been changed to be initialized with `::new()` instead of struct initialization to make us of `Option::None`s 
- The word `partial` has been removed from some tests 
- `Meta` prefix in structs used in tests have been removed

## Related Issues

Closes #315 
