### PR TITLE
Bump Repo

### DIFF
--- a/.docs/contributing-book/src/code/Forc.toml
+++ b/.docs/contributing-book/src/code/Forc.toml
@@ -1,1 +1,2 @@
+[workspace]
 members = ["./bad_documentation", "./connect_four", "./style_guide"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.64.0
+  RUST_VERSION: 1.66.0
   FORC_VERSION: 0.32.1
   CORE_VERSION: 0.15.1
   PATH_TO_SCRIPTS: .github/scripts
@@ -56,15 +56,6 @@ jobs:
       - name: Init cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Install a modern linker (mold)
-        uses: rui314/setup-mold@v1
-
-      - name: Force Rust to use mold globally for compilation
-        run: |
-          touch ~/.cargo/config.toml
-          echo "[target.x86_64-unknown-linux-gnu]" > ~/.cargo/config.toml
-          echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> ~/.cargo/config.toml
       - name: Install rustfmt
         run: rustup component add rustfmt
 
@@ -111,15 +102,6 @@ jobs:
       - name: Init cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Install a modern linker (mold)
-        uses: rui314/setup-mold@v1
-
-      - name: Force Rust to use mold globally for compilation
-        run: |
-          touch ~/.cargo/config.toml
-          echo "[target.x86_64-unknown-linux-gnu]" > ~/.cargo/config.toml
-          echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> ~/.cargo/config.toml
       - name: Install rustfmt
         run: rustup component add rustfmt
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   RUST_VERSION: 1.66.0
-  FORC_VERSION: 0.32.1
+  FORC_VERSION: 0.32.2
   CORE_VERSION: 0.15.1
   PATH_TO_SCRIPTS: .github/scripts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ concurrency:
 env:
   REGISTRY: ghcr.io
   RUST_VERSION: 1.64.0
-  FORC_VERSION: 0.31.1
-  CORE_VERSION: 0.14.1
+  FORC_VERSION: 0.32.1
+  CORE_VERSION: 0.15.1
   PATH_TO_SCRIPTS: .github/scripts
 
 jobs:

--- a/AMM/Forc.toml
+++ b/AMM/Forc.toml
@@ -1,3 +1,4 @@
+[workspace]
 members = [
   "./project/contracts/AMM-contract",
   "./project/contracts/exchange-contract",

--- a/AMM/project/contracts/AMM-contract/Cargo.toml
+++ b/AMM/project/contracts/AMM-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 
 [[test]]

--- a/AMM/project/contracts/AMM-contract/Cargo.toml
+++ b/AMM/project/contracts/AMM-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 
 [[test]]

--- a/AMM/project/contracts/AMM-contract/tests/functions/add_pool.rs
+++ b/AMM/project/contracts/AMM-contract/tests/functions/add_pool.rs
@@ -77,7 +77,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "BytecodeRootNotSet")]
     async fn when_not_initialized() {
         let (wallet, amm_instance, asset_pairs) = setup().await;
         let pair = asset_pairs[0];
@@ -88,7 +88,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "BytecodeRootDoesNotMatch")]
     async fn when_exchange_contract_byteroot_invalid() {
         let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
         let pair = asset_pairs[0];
@@ -100,7 +100,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "PairDoesNotDefinePool")]
     async fn when_exchange_contract_does_not_match_pair() {
         let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
         let pair = asset_pairs[0];

--- a/AMM/project/contracts/AMM-contract/tests/functions/initialize.rs
+++ b/AMM/project/contracts/AMM-contract/tests/functions/initialize.rs
@@ -21,7 +21,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "BytecodeRootAlreadySet")]
     async fn when_already_initialized() {
         let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
 

--- a/AMM/project/contracts/AMM-contract/tests/utils/mod.rs
+++ b/AMM/project/contracts/AMM-contract/tests/utils/mod.rs
@@ -1,4 +1,4 @@
-use fuels::{contract::contract::CallResponse, prelude::*, tx::Contract as TxContract};
+use fuels::{contract::call_response::FuelCallResponse, prelude::*, tx::Contract as TxContract};
 
 abigen!(
     AMM,
@@ -29,7 +29,7 @@ pub mod exchange_abi_calls {
     pub async fn constructor(
         contract: &Exchange,
         pair: (ContractId, ContractId),
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         let receipt = contract.methods().constructor(pair).call().await;
         receipt.unwrap()
     }
@@ -41,7 +41,7 @@ pub mod amm_abi_calls {
     pub async fn initialize(
         contract: &AMM,
         exchange_bytecode_root: ContractId,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .initialize(exchange_bytecode_root)
@@ -54,7 +54,7 @@ pub mod amm_abi_calls {
         contract: &AMM,
         asset_pair: (ContractId, ContractId),
         pool: ContractId,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .add_pool(asset_pair, pool)

--- a/AMM/project/contracts/exchange-contract/Cargo.toml
+++ b/AMM/project/contracts/exchange-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 
 [[test]]

--- a/AMM/project/contracts/exchange-contract/Cargo.toml
+++ b/AMM/project/contracts/exchange-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 
 [[test]]

--- a/AMM/project/contracts/exchange-contract/src/utils.sw
+++ b/AMM/project/contracts/exchange-contract/src/utils.sw
@@ -2,7 +2,7 @@ library utils;
 
 dep errors;
 
-use core::num::*;
+use core::primitives::*;
 use errors::{InitError, InputError};
 use std::u128::U128;
 

--- a/AMM/project/contracts/exchange-contract/tests/functions/add_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/add_liquidity.rs
@@ -215,7 +215,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, _asset_a_id, _asset_b_id, _asset_c_id) =
@@ -234,7 +234,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DeadlinePassed")]
     async fn when_deadline_has_passed() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
@@ -249,7 +249,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountMustBeZero")]
     async fn when_msg_amount_is_not_zero() {
         let (exchange, _wallet, amounts, _asset_c_id) =
             setup_initialize_and_deposit_but_do_not_add_liquidity().await;
@@ -270,7 +270,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountTooLow")]
     async fn when_desired_liquidity_is_less_than_minimum_liquidity() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
@@ -285,7 +285,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DepositCannotBeZero")]
     async fn when_deposited_a_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
@@ -300,7 +300,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DepositCannotBeZero")]
     async fn when_deposited_b_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
@@ -315,7 +315,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_liquidity_is_zero_but_desired_liquidity_is_too_high() {
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
 
@@ -330,7 +330,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_liquidity_exists_but_desired_liquidity_is_too_high_based_on_a() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -346,7 +346,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_liquidity_exists_but_desired_liquidity_is_too_high_based_on_b() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;

--- a/AMM/project/contracts/exchange-contract/tests/functions/balance.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/balance.rs
@@ -38,7 +38,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
@@ -48,7 +48,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
         let (exchange, _wallet, _amounts, asset_c_id) = setup_and_initialize().await;
 

--- a/AMM/project/contracts/exchange-contract/tests/functions/constructor.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/constructor.rs
@@ -24,7 +24,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotReinitialize")]
     async fn when_reinitialized() {
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, asset_b_id, _asset_c_id) =
             setup().await;
@@ -34,7 +34,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "PoolAssetsCannotBeIdentical")]
     async fn when_assets_in_pair_are_identical() {
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
             setup().await;

--- a/AMM/project/contracts/exchange-contract/tests/functions/deposit.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/deposit.rs
@@ -76,7 +76,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
@@ -91,7 +91,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
         let (exchange, _wallet, _amounts, asset_c_id) = setup_and_initialize().await;
         let deposit_amount = 100;

--- a/AMM/project/contracts/exchange-contract/tests/functions/pool_info.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/pool_info.rs
@@ -55,7 +55,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, _asset_a_id, _asset_b_id, _asset_c_id) =

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_add_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_add_liquidity.rs
@@ -196,7 +196,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_input.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_input.rs
@@ -57,7 +57,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
@@ -67,7 +67,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
         let (exchange, _wallet, _amounts, asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_output.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_output.rs
@@ -115,7 +115,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, _asset_a_id, asset_b_id, _asset_c_id) =
@@ -125,7 +125,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
         let (exchange, _wallet, _amounts, asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -140,7 +140,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_output_b_amount_is_greater_than_reserve() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -151,7 +151,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_output_a_amount_is_greater_than_reserve() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;

--- a/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
@@ -417,7 +417,7 @@ mod revert {
                 Some(1),
                 // Sending `None` instead of `Some(exchange.liquidity_pool_asset)`
                 // because liquidity pool asset does not exist yet.
-                // Normally, this also causes ,
+                // Normally, this also causes Revert(18446744073709486080),
                 // but this test condition (zero liquidity) reverts before that.
                 None,
                 None,

--- a/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
@@ -258,7 +258,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, _asset_a_id, _asset_b_id, _asset_c_id) =
@@ -273,7 +273,7 @@ mod revert {
                 Some(1),
                 // Sending `None` instead of `Some(AssetId::new(*pool_asset_id))`
                 // because liquidity pool asset does not exist yet.
-                // Normally, this also causes Revert(18446744073709486080),
+                // Normally, this also causes ,
                 // but this test condition (not initialized contract) reverts before that.
                 None,
                 None,
@@ -286,7 +286,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_not_liquidity_pool_asset_id() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -310,7 +310,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn when_minimum_a_amount_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -333,7 +333,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn when_minimum_b_amount_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -356,7 +356,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DeadlinePassed")]
     async fn when_deadline_has_passed() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -380,7 +380,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn when_msg_amount_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -404,7 +404,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "LiquidityCannotBeZero")]
     async fn when_liquidity_is_zero() {
         // not adding liquidity to contract before attempting to remove
         let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
@@ -417,7 +417,7 @@ mod revert {
                 Some(1),
                 // Sending `None` instead of `Some(exchange.liquidity_pool_asset)`
                 // because liquidity pool asset does not exist yet.
-                // Normally, this also causes Revert(18446744073709486080),
+                // Normally, this also causes ,
                 // but this test condition (zero liquidity) reverts before that.
                 None,
                 None,
@@ -430,7 +430,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_a_reserve_is_insufficient() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -458,7 +458,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_b_reserve_is_insufficient() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;

--- a/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
@@ -273,7 +273,7 @@ mod revert {
                 Some(1),
                 // Sending `None` instead of `Some(AssetId::new(*pool_asset_id))`
                 // because liquidity pool asset does not exist yet.
-                // Normally, this also causes ,
+                // Normally, this also causes Revert(18446744073709486080),
                 // but this test condition (not initialized contract) reverts before that.
                 None,
                 None,

--- a/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_input.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_input.rs
@@ -146,7 +146,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
@@ -164,7 +164,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
         let (exchange, _wallet, amounts, asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -180,7 +180,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DeadlinePassed")]
     async fn when_deadline_has_passed() {
         let (exchange, _wallet, _amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -196,7 +196,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn when_msg_amount_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -212,7 +212,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_minimum_a_constraint_is_too_high() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;

--- a/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_output.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_output.rs
@@ -212,7 +212,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn when_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
@@ -230,7 +230,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
         let (exchange, _wallet, amounts, asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -248,7 +248,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn when_output_amount_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -264,7 +264,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DeadlinePassed")]
     async fn when_deadline_has_passed() {
         let (exchange, _wallet, _amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -282,7 +282,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn when_msg_amount_is_zero() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -300,7 +300,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ProvidedAmountTooLow")]
     async fn when_forwarding_insufficient_amount_of_a() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;
@@ -329,7 +329,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ProvidedAmountTooLow")]
     async fn when_forwarding_insufficient_amount_of_b() {
         let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
             setup_initialize_deposit_and_add_liquidity().await;

--- a/AMM/project/contracts/exchange-contract/tests/functions/withdraw.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/withdraw.rs
@@ -72,7 +72,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitialized")]
     async fn on_unitialized() {
         // call setup instead of setup_and_initialize
         let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
@@ -82,7 +82,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAsset")]
     async fn on_invalid_asset() {
         let (exchange, _wallet, _amounts, asset_c_id) = setup_and_initialize().await;
         let deposit_amount = 100;
@@ -98,7 +98,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn on_withdraw_more_than_deposited() {
         let (exchange, _wallet, _amounts, _asset_c_id) = setup_and_initialize().await;
         let deposit_amount = 100;

--- a/AMM/project/contracts/exchange-contract/tests/utils/mod.rs
+++ b/AMM/project/contracts/exchange-contract/tests/utils/mod.rs
@@ -1,4 +1,4 @@
-use fuels::{contract::contract::CallResponse, prelude::*};
+use fuels::{contract::call_response::FuelCallResponse, prelude::*};
 
 abigen!(
     Exchange,
@@ -43,7 +43,7 @@ pub mod abi_calls {
         tx_params: TxParameters,
         desired_liquidity: u64,
         deadline: u64,
-    ) -> CallResponse<u64> {
+    ) -> FuelCallResponse<u64> {
         contract
             .methods()
             .add_liquidity(desired_liquidity, deadline)
@@ -58,7 +58,10 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn constructor(contract: &Exchange, pair: (AssetId, AssetId)) -> CallResponse<()> {
+    pub async fn constructor(
+        contract: &Exchange,
+        pair: (AssetId, AssetId),
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .constructor((ContractId::new(*pair.0), ContractId::new(*pair.1)))
@@ -67,7 +70,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn deposit(contract: &Exchange, call_params: CallParameters) -> CallResponse<()> {
+    pub async fn deposit(contract: &Exchange, call_params: CallParameters) -> FuelCallResponse<()> {
         contract
             .methods()
             .deposit()
@@ -83,7 +86,7 @@ pub mod abi_calls {
         min_asset_a: u64,
         min_asset_b: u64,
         deadline: u64,
-    ) -> CallResponse<RemoveLiquidityInfo> {
+    ) -> FuelCallResponse<RemoveLiquidityInfo> {
         contract
             .methods()
             .remove_liquidity(min_asset_a, min_asset_b, deadline)
@@ -100,7 +103,7 @@ pub mod abi_calls {
         call_params: CallParameters,
         min_output: Option<u64>,
         deadline: u64,
-    ) -> CallResponse<u64> {
+    ) -> FuelCallResponse<u64> {
         contract
             .methods()
             .swap_exact_input(min_output, deadline)
@@ -117,7 +120,7 @@ pub mod abi_calls {
         call_params: CallParameters,
         output: u64,
         deadline: u64,
-    ) -> CallResponse<u64> {
+    ) -> FuelCallResponse<u64> {
         contract
             .methods()
             .swap_exact_output(output, deadline)
@@ -129,7 +132,11 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn withdraw(contract: &Exchange, amount: u64, asset: AssetId) -> CallResponse<()> {
+    pub async fn withdraw(
+        contract: &Exchange,
+        amount: u64,
+        asset: AssetId,
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .withdraw(amount, ContractId::new(*asset))
@@ -139,7 +146,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn balance(contract: &Exchange, asset: AssetId) -> CallResponse<u64> {
+    pub async fn balance(contract: &Exchange, asset: AssetId) -> FuelCallResponse<u64> {
         contract
             .methods()
             .balance(ContractId::new(*asset))
@@ -148,7 +155,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn pool_info(contract: &Exchange) -> CallResponse<PoolInfo> {
+    pub async fn pool_info(contract: &Exchange) -> FuelCallResponse<PoolInfo> {
         contract.methods().pool_info().call().await.unwrap()
     }
 
@@ -158,7 +165,7 @@ pub mod abi_calls {
         tx_params: TxParameters,
         amount: u64,
         asset: AssetId,
-    ) -> CallResponse<PreviewAddLiquidityInfo> {
+    ) -> FuelCallResponse<PreviewAddLiquidityInfo> {
         contract
             .methods()
             .preview_add_liquidity(amount, ContractId::new(*asset))
@@ -173,7 +180,7 @@ pub mod abi_calls {
         contract: &Exchange,
         exact_input: u64,
         input_asset: AssetId,
-    ) -> CallResponse<PreviewSwapInfo> {
+    ) -> FuelCallResponse<PreviewSwapInfo> {
         contract
             .methods()
             .preview_swap_exact_input(exact_input, ContractId::new(*input_asset))
@@ -187,7 +194,7 @@ pub mod abi_calls {
         contract: &Exchange,
         exact_output: u64,
         output_asset: AssetId,
-    ) -> CallResponse<PreviewSwapInfo> {
+    ) -> FuelCallResponse<PreviewSwapInfo> {
         contract
             .methods()
             .preview_swap_exact_output(exact_output, ContractId::new(*output_asset))

--- a/DAO/Forc.toml
+++ b/DAO/Forc.toml
@@ -1,3 +1,4 @@
+[workspace]
 members = [
   "./project/DAO-contract",
   "./project/DAO-contract/tests/artifacts/gov_token",

--- a/DAO/project/DAO-contract/Cargo.toml
+++ b/DAO/project/DAO-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/DAO/project/DAO-contract/Cargo.toml
+++ b/DAO/project/DAO-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/DAO/project/DAO-contract/tests/functions/constructor.rs
+++ b/DAO/project/DAO-contract/tests/functions/constructor.rs
@@ -21,7 +21,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotReinitialize")]
     async fn when_reinitialized() {
         let (_gov_token, gov_token_id, deployer, _user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;

--- a/DAO/project/DAO-contract/tests/functions/create_proposal.rs
+++ b/DAO/project/DAO-contract/tests/functions/create_proposal.rs
@@ -70,7 +70,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DurationCannotBeZero")]
     async fn when_duration_is_zero() {
         let (_gov_token, gov_token_id, deployer, _user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
@@ -80,7 +80,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAcceptancePercentage")]
     async fn with_zero_acceptance_percentage() {
         let (_gov_token, gov_token_id, deployer, _user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
@@ -90,7 +90,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidAcceptancePercentage")]
     async fn with_over_hundred_acceptance_percentage() {
         let (_gov_token, gov_token_id, deployer, _user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;

--- a/DAO/project/DAO-contract/tests/functions/deposit.rs
+++ b/DAO/project/DAO-contract/tests/functions/deposit.rs
@@ -54,7 +54,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ContractNotInitialized")]
     async fn when_not_initialized() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 
@@ -74,7 +74,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAssetSent")]
     async fn with_incorrect_asset() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 
@@ -103,7 +103,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn on_zero_deposit() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 

--- a/DAO/project/DAO-contract/tests/functions/execute.rs
+++ b/DAO/project/DAO-contract/tests/functions/execute.rs
@@ -41,14 +41,14 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidId")]
     async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         execute(&user.dao_voting, 0).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ProposalExecuted")]
     #[ignore]
     async fn on_already_executed_proposal() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
@@ -77,7 +77,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ProposalStillActive")]
     pub async fn on_active_proposal() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
@@ -104,7 +104,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InsufficientApprovals")]
     pub async fn on_not_enough_yes_votes() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
@@ -124,7 +124,7 @@ mod revert {
         deposit(&user.dao_voting, call_params).await;
 
         let proposal_transaction = proposal_transaction(gov_token_id);
-        create_proposal(&user.dao_voting, 10, 100, proposal_transaction.clone()).await;
+        create_proposal(&user.dao_voting, 10, 1, proposal_transaction.clone()).await;
         vote(&user.dao_voting, false, 0, asset_amount / 2).await;
 
         execute(&user.dao_voting, 0).await;

--- a/DAO/project/DAO-contract/tests/functions/governance_token_id.rs
+++ b/DAO/project/DAO-contract/tests/functions/governance_token_id.rs
@@ -21,7 +21,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ContractNotInitialized")]
     pub async fn on_not_inialized() {
         let (_gov_token, _gov_token_id, deployer, _user, _asset_amount) = setup().await;
         governance_token_id(&deployer.dao_voting).await;

--- a/DAO/project/DAO-contract/tests/functions/proposal.rs
+++ b/DAO/project/DAO-contract/tests/functions/proposal.rs
@@ -35,7 +35,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidId")]
     async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         proposal(&user.dao_voting, 0).await;

--- a/DAO/project/DAO-contract/tests/functions/unlock_votes.rs
+++ b/DAO/project/DAO-contract/tests/functions/unlock_votes.rs
@@ -214,14 +214,14 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidId")]
     async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         unlock_votes(&user.dao_voting, 0).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ProposalStillActive")]
     pub async fn on_active_proposal() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;

--- a/DAO/project/DAO-contract/tests/functions/user_votes.rs
+++ b/DAO/project/DAO-contract/tests/functions/user_votes.rs
@@ -50,7 +50,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidId")]
     pub async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         user_votes(&user.dao_voting, user.wallet.address(), 0).await;

--- a/DAO/project/DAO-contract/tests/functions/vote.rs
+++ b/DAO/project/DAO-contract/tests/functions/vote.rs
@@ -124,14 +124,14 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidId")]
     async fn on_invalid_proposal_id() {
         let (_gov_token, _gov_token_id, _deployer, user, _asset_amount) = setup().await;
         vote(&user.dao_voting, true, 0, 10).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "VoteAmountCannotBeZero")]
     async fn on_zero_vote_amount() {
         let (_gov_token, gov_token_id, deployer, user, _asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
@@ -142,7 +142,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ProposalExpired")]
     async fn on_expired_proposal() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
@@ -167,13 +167,13 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InsufficientBalance")]
     async fn on_vote_amount_greater_than_balance() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
         constructor(&deployer.dao_voting, gov_token_id).await;
 
         let proposal_transaction = proposal_transaction(gov_token_id);
         create_proposal(&user.dao_voting, 10, 10, proposal_transaction.clone()).await;
-        vote(&user.dao_voting, true, 10, asset_amount).await;
+        vote(&user.dao_voting, true, 0, asset_amount).await;
     }
 }

--- a/DAO/project/DAO-contract/tests/functions/withdraw.rs
+++ b/DAO/project/DAO-contract/tests/functions/withdraw.rs
@@ -49,7 +49,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn on_withdraw_zero() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 
@@ -72,7 +72,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InsufficientBalance")]
     async fn on_not_enough_assets() {
         let (_gov_token, gov_token_id, deployer, user, asset_amount) = setup().await;
 

--- a/DAO/project/DAO-contract/tests/utils/mod.rs
+++ b/DAO/project/DAO-contract/tests/utils/mod.rs
@@ -1,4 +1,4 @@
-use fuels::{contract::contract::CallResponse, prelude::*, tx::ContractId};
+use fuels::{contract::call_response::FuelCallResponse, prelude::*, tx::ContractId};
 
 abigen!(
     DaoVoting,
@@ -28,7 +28,7 @@ pub mod abi_calls {
 
     use super::*;
 
-    pub async fn constructor(contract: &DaoVoting, token: ContractId) -> CallResponse<()> {
+    pub async fn constructor(contract: &DaoVoting, token: ContractId) -> FuelCallResponse<()> {
         contract.methods().constructor(token).call().await.unwrap()
     }
 
@@ -37,7 +37,7 @@ pub mod abi_calls {
         acceptance_percentage: u64,
         deadline: u64,
         proposal: Proposal,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .create_proposal(acceptance_percentage, deadline, proposal)
@@ -46,7 +46,10 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn deposit(contract: &DaoVoting, call_params: CallParameters) -> CallResponse<()> {
+    pub async fn deposit(
+        contract: &DaoVoting,
+        call_params: CallParameters,
+    ) -> FuelCallResponse<()> {
         let tx_params = TxParameters::new(None, Some(1_000_000), None);
         contract
             .methods()
@@ -58,7 +61,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn withdraw(contract: &DaoVoting, amount: u64) -> CallResponse<()> {
+    pub async fn withdraw(contract: &DaoVoting, amount: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .withdraw(amount)
@@ -73,7 +76,7 @@ pub mod abi_calls {
         approve: bool,
         proposal_id: u64,
         vote_amount: u64,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .vote(approve, proposal_id, vote_amount)
@@ -82,11 +85,11 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn execute(contract: &DaoVoting, id: u64) -> CallResponse<()> {
+    pub async fn execute(contract: &DaoVoting, id: u64) -> FuelCallResponse<()> {
         contract.methods().execute(id).call().await.unwrap()
     }
 
-    pub async fn unlock_votes(contract: &DaoVoting, id: u64) -> CallResponse<()> {
+    pub async fn unlock_votes(contract: &DaoVoting, id: u64) -> FuelCallResponse<()> {
         contract.methods().unlock_votes(id).call().await.unwrap()
     }
 

--- a/NFT/Forc.toml
+++ b/NFT/Forc.toml
@@ -1,1 +1,2 @@
+[workspace]
 members = ["./project/NFT-contract"]

--- a/NFT/project/NFT-contract/Cargo.toml
+++ b/NFT/project/NFT-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/NFT/project/NFT-contract/Cargo.toml
+++ b/NFT/project/NFT-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/NFT/project/NFT-contract/tests/functions/approve.rs
+++ b/NFT/project/NFT-contract/tests/functions/approve.rs
@@ -76,7 +76,7 @@ mod reverts {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "TokenDoesNotExist")]
     async fn when_token_does_not_map_to_existing_token() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 
@@ -87,7 +87,7 @@ mod reverts {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NoContractAdmin")]
     async fn when_sender_is_not_owner() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 

--- a/NFT/project/NFT-contract/tests/functions/burn.rs
+++ b/NFT/project/NFT-contract/tests/functions/burn.rs
@@ -61,7 +61,7 @@ mod reverts {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "TokenDoesNotExist")]
     async fn when_token_owner_does_not_exist() {
         let (_deploy_wallet, owner1, _owner2) = setup().await;
 
@@ -69,7 +69,7 @@ mod reverts {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "TokenDoesNotExist")]
     async fn when_token_does_not_exist() {
         let (deploy_wallet, owner1, _owner2) = setup().await;
 
@@ -82,7 +82,7 @@ mod reverts {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NoContractAdmin")]
     async fn when_sender_is_not_owner() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 

--- a/NFT/project/NFT-contract/tests/functions/constructor.rs
+++ b/NFT/project/NFT-contract/tests/functions/constructor.rs
@@ -76,7 +76,7 @@ mod reverts {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotReinitialize")]
     async fn when_initalized_twice() {
         let (deploy_wallet, _owner1, _owner2) = setup().await;
 

--- a/NFT/project/NFT-contract/tests/functions/mint.rs
+++ b/NFT/project/NFT-contract/tests/functions/mint.rs
@@ -128,7 +128,7 @@ mod reverts {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "MaxTokensMinted")]
     async fn when_minting_more_tokens_than_supply() {
         let (deploy_wallet, owner1, _owner2) = setup().await;
 
@@ -144,7 +144,7 @@ mod reverts {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderNotAdmin")]
     async fn when_minter_does_not_have_access() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 

--- a/NFT/project/NFT-contract/tests/functions/set_admin.rs
+++ b/NFT/project/NFT-contract/tests/functions/set_admin.rs
@@ -33,7 +33,7 @@ mod reverts {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NoContractAdmin")]
     async fn when_not_initalized() {
         let (_deploy_wallet, owner1, _owner2) = setup().await;
 
@@ -42,7 +42,7 @@ mod reverts {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderNotAdmin")]
     async fn when_not_admin_identity() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 

--- a/NFT/project/NFT-contract/tests/functions/transfer.rs
+++ b/NFT/project/NFT-contract/tests/functions/transfer.rs
@@ -131,7 +131,7 @@ mod reverts {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "TokenDoesNotExist")]
     async fn when_token_does_not_exist() {
         let (_deploy_wallet, owner1, owner2) = setup().await;
 
@@ -140,7 +140,7 @@ mod reverts {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderNotAdmin")]
     async fn when_sender_is_not_owner_or_approved() {
         let (deploy_wallet, owner1, owner2) = setup().await;
 

--- a/NFT/project/NFT-contract/tests/utils/mod.rs
+++ b/NFT/project/NFT-contract/tests/utils/mod.rs
@@ -1,4 +1,4 @@
-use fuels::{contract::contract::CallResponse, prelude::*};
+use fuels::{contract::call_response::FuelCallResponse, prelude::*};
 
 abigen!(
     Nft,
@@ -27,7 +27,7 @@ pub mod abi_calls {
         approved: Option<Identity>,
         contract: &Nft,
         token_id: u64,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .approve(approved.clone(), token_id)
@@ -56,7 +56,7 @@ pub mod abi_calls {
             .value
     }
 
-    pub async fn burn(contract: &Nft, token_id: u64) -> CallResponse<()> {
+    pub async fn burn(contract: &Nft, token_id: u64) -> FuelCallResponse<()> {
         contract.methods().burn(token_id).call().await.unwrap()
     }
 
@@ -64,7 +64,7 @@ pub mod abi_calls {
         admin: Option<Identity>,
         contract: &Nft,
         token_supply: Option<u64>,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .constructor(admin.clone(), token_supply.clone())
@@ -87,7 +87,7 @@ pub mod abi_calls {
         contract.methods().max_supply().call().await.unwrap().value
     }
 
-    pub async fn mint(amount: u64, contract: &Nft, owner: Identity) -> CallResponse<()> {
+    pub async fn mint(amount: u64, contract: &Nft, owner: Identity) -> FuelCallResponse<()> {
         contract
             .methods()
             .mint(amount, owner.clone())
@@ -110,7 +110,7 @@ pub mod abi_calls {
         approve: bool,
         contract: &Nft,
         operator: Identity,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .set_approval_for_all(approve, operator.clone())
@@ -119,7 +119,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn set_admin(contract: &Nft, minter: Option<Identity>) -> CallResponse<()> {
+    pub async fn set_admin(contract: &Nft, minter: Option<Identity>) -> FuelCallResponse<()> {
         contract
             .methods()
             .set_admin(minter.clone())
@@ -148,7 +148,7 @@ pub mod abi_calls {
             .value
     }
 
-    pub async fn transfer(contract: &Nft, to: Identity, token_id: u64) -> CallResponse<()> {
+    pub async fn transfer(contract: &Nft, to: Identity, token_id: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .transfer(to.clone(), token_id)

--- a/OTC-swap-predicate/Forc.toml
+++ b/OTC-swap-predicate/Forc.toml
@@ -1,1 +1,2 @@
+[workspace]
 members = ["./project/swap-predicate"]

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-applications/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-applications/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.32.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.32.1-orange" />
+    <a href="https://crates.io/crates/forc/0.32.2" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.32.2-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-applications" />
@@ -68,7 +68,7 @@ If you wish to run any of the projects then clone this repository and go through
 Any instructions related to running a specific project should be found within the README.md of that project.
 
 > **Note**
-> All projects currently use `forc 0.32.1`, and `fuel-core 0.15.1`.
+> All projects currently use `forc 0.32.2`, and `fuel-core 0.15.1`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
     <a href="https://github.com/FuelLabs/sway-applications/actions/workflows/ci.yml" alt="CI">
         <img src="https://github.com/FuelLabs/sway-applications/actions/workflows/ci.yml/badge.svg" />
     </a>
-    <a href="https://crates.io/crates/forc/0.31.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.31.1-orange" />
+    <a href="https://crates.io/crates/forc/0.32.1" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.32.1-orange" />
     </a>
     <a href="./LICENSE" alt="forc">
         <img src="https://img.shields.io/github/license/FuelLabs/sway-applications" />
@@ -68,7 +68,7 @@ If you wish to run any of the projects then clone this repository and go through
 Any instructions related to running a specific project should be found within the README.md of that project.
 
 > **Note**
-> All projects currently use `forc 0.31.1`, and `fuel-core 0.14.1`.
+> All projects currently use `forc 0.32.1`, and `fuel-core 0.15.1`.
 
 ## Contributing
 

--- a/airdrop/Forc.toml
+++ b/airdrop/Forc.toml
@@ -1,3 +1,4 @@
+[workspace]
 members = [
   "./project/contracts/distributor-contract",
   "./project/contracts/asset-contract",

--- a/airdrop/project/contracts/asset-contract/Cargo.toml
+++ b/airdrop/project/contracts/asset-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/airdrop/project/contracts/asset-contract/Cargo.toml
+++ b/airdrop/project/contracts/asset-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/airdrop/project/contracts/asset-contract/tests/functions/constructor.rs
+++ b/airdrop/project/contracts/asset-contract/tests/functions/constructor.rs
@@ -19,7 +19,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AlreadyInitialized")]
     async fn when_initalized_twice() {
         let (deployer, _, total_supply) = setup().await;
 
@@ -29,7 +29,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AssetSupplyCannotBeZero")]
     async fn when_asset_supply_zero() {
         let (deployer, _, _) = setup().await;
 

--- a/airdrop/project/contracts/asset-contract/tests/functions/mint_to.rs
+++ b/airdrop/project/contracts/asset-contract/tests/functions/mint_to.rs
@@ -116,7 +116,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderNotPermittedToMint")]
     async fn when_sender_not_minter() {
         let (deployer, false_minter, total_supply) = setup().await;
 
@@ -139,7 +139,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "GreaterThanMaximumSupply")]
     async fn when_mint_more_than_supply() {
         let (deployer, _, total_supply) = setup().await;
 
@@ -150,7 +150,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderNotPermittedToMint")]
     async fn when_not_initalized() {
         let (deployer, _, total_supply) = setup().await;
 

--- a/airdrop/project/contracts/asset-contract/tests/utils/mod.rs
+++ b/airdrop/project/contracts/asset-contract/tests/utils/mod.rs
@@ -1,4 +1,4 @@
-use fuels::{contract::contract::CallResponse, prelude::*};
+use fuels::{contract::call_response::FuelCallResponse, prelude::*};
 
 abigen!(
     SimpleAsset,
@@ -24,7 +24,7 @@ pub mod abi_calls {
         asset_supply: u64,
         contract: &SimpleAsset,
         minter: Identity,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .constructor(asset_supply, minter)
@@ -33,7 +33,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn mint_to(amount: u64, contract: &SimpleAsset, to: Identity) -> CallResponse<()> {
+    pub async fn mint_to(amount: u64, contract: &SimpleAsset, to: Identity) -> FuelCallResponse<()> {
         contract
             .methods()
             .mint_to(amount, to)

--- a/airdrop/project/contracts/asset-contract/tests/utils/mod.rs
+++ b/airdrop/project/contracts/asset-contract/tests/utils/mod.rs
@@ -33,7 +33,11 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn mint_to(amount: u64, contract: &SimpleAsset, to: Identity) -> FuelCallResponse<()> {
+    pub async fn mint_to(
+        amount: u64,
+        contract: &SimpleAsset,
+        to: Identity,
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .mint_to(amount, to)

--- a/airdrop/project/contracts/distributor-contract/Cargo.toml
+++ b/airdrop/project/contracts/distributor-contract/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 fuel-merkle = { version = "0.4.1" }
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/airdrop/project/contracts/distributor-contract/Cargo.toml
+++ b/airdrop/project/contracts/distributor-contract/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 fuel-merkle = { version = "0.4.1" }
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 sha2 = { version = "0.10" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/airdrop/project/contracts/distributor-contract/tests/functions/claim.rs
+++ b/airdrop/project/contracts/distributor-contract/tests/functions/claim.rs
@@ -299,7 +299,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ClaimPeriodHasEnded")]
     async fn after_claim_period() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
         let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, _, _) =
@@ -327,7 +327,7 @@ mod revert {
     // The issue can be tracked here: https://github.com/FuelLabs/sway/issues/2594
     #[ignore]
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "UserAlreadyClaimed")]
     async fn when_claim_twice() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
         let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, _) =
@@ -370,7 +370,7 @@ mod revert {
     // TODO: This test will be removed and replaced by `panics_when_claim_twice()` when
     // https://github.com/FuelLabs/sway/issues/2594 is resolved
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "UserAlreadyClaimed")]
     async fn when_claim_twice_manual_tree() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
         let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, depth) =
@@ -433,7 +433,7 @@ mod revert {
     // The issue can be tracked here: https://github.com/FuelLabs/sway/issues/2594
     #[ignore]
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "MerkleProofFailed")]
     async fn when_failed_merkle_verification() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
         let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, _) =
@@ -466,7 +466,7 @@ mod revert {
     // TODO: This test will be removed and replaced by `panics_when_failed_merkle_verification()` when
     // https://github.com/FuelLabs/sway/issues/2594 is resolved
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "MerkleProofFailed")]
     async fn when_failed_merkle_verification_manual_tree() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
         let (_, _, _, minter, key, num_leaves, asset_supply, airdrop_leaves, claim_time, depth) =
@@ -497,7 +497,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ClaimPeriodHasEnded")]
     async fn when_not_initalized() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
         let (_, _, _, _minter, key, num_leaves, _, airdrop_leaves, _, _) =

--- a/airdrop/project/contracts/distributor-contract/tests/functions/constructor.rs
+++ b/airdrop/project/contracts/distributor-contract/tests/functions/constructor.rs
@@ -39,7 +39,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AlreadyInitialized")]
     async fn when_already_initalized() {
         let (deploy_wallet, wallet1, wallet2, wallet3, asset) = setup().await;
         let (_, _, _, _, _, _, _, _, claim_time, _) =

--- a/airdrop/project/contracts/distributor-contract/tests/functions/merkle_root.rs
+++ b/airdrop/project/contracts/distributor-contract/tests/functions/merkle_root.rs
@@ -32,7 +32,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotInitalized")]
     async fn when_not_initalized() {
         let (deploy_wallet, _, _, _, _) = setup().await;
 

--- a/airdrop/project/contracts/distributor-contract/tests/utils/mod.rs
+++ b/airdrop/project/contracts/distributor-contract/tests/utils/mod.rs
@@ -2,7 +2,7 @@ use fuel_merkle::{
     binary::in_memory::MerkleTree,
     common::{empty_sum_sha256, Bytes32},
 };
-use fuels::{contract::contract::CallResponse, core::types::Bits256, prelude::*};
+use fuels::{contract::call_response::FuelCallResponse, core::types::Bits256, prelude::*};
 use sha2::{Digest, Sha256};
 
 abigen!(
@@ -46,7 +46,7 @@ pub mod airdrop_distributor_abi_calls {
         num_leaves: u64,
         proof: Vec<Bits256>,
         to: Identity,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .claim(amount, key, num_leaves, proof, to)
@@ -72,7 +72,7 @@ pub mod airdrop_distributor_abi_calls {
         claim_time: u64,
         contract: &AirdropDistributor,
         merkle_root: Bits256,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .constructor(asset, claim_time, merkle_root)
@@ -98,7 +98,7 @@ pub mod simple_asset_abi_calls {
         asset_supply: u64,
         contract: &SimpleAsset,
         minter: Identity,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .constructor(asset_supply, minter)

--- a/auctions/Forc.toml
+++ b/auctions/Forc.toml
@@ -1,3 +1,4 @@
+[workspace]
 members = [
   "./english-auction/project/auction-contract",
   "./english-auction/project/auction-contract/tests/artifacts/asset",

--- a/auctions/english-auction/project/auction-contract/Cargo.toml
+++ b/auctions/english-auction/project/auction-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/auctions/english-auction/project/auction-contract/Cargo.toml
+++ b/auctions/english-auction/project/auction-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/auctions/english-auction/project/auction-contract/tests/functions/auction_info.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/auction_info.rs
@@ -1,7 +1,7 @@
 use crate::utils::{
     asset_abi_calls::mint_and_send_to_address,
     english_auction_abi_calls::{auction_info, bid, create},
-    englishauction_mod::State,
+    english_auction_mod::State,
     test_helpers::{create_auction_copy, defaults_token, setup, token_asset},
 };
 use fuels::prelude::Identity;

--- a/auctions/english-auction/project/auction-contract/tests/functions/bid.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/bid.rs
@@ -653,8 +653,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[ignore]
-    // TODO: test is not set up to hit the error properly
+    #[should_panic(expected = "Revert(18446744073709486080)")]
+    // TODO: test is not set up to hit the error properly: https://github.com/FuelLabs/sway-applications/issues/330
     // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_bidder_does_not_own_nft() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, _, buy_nft_contract_id) =
@@ -684,8 +684,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[ignore]
-    // TODO: test is not set up to hit the error properly
+    #[should_panic(expected = "Revert(18446744073709486080)")]
+    // TODO: test is not set up to hit the error properly: https://github.com/FuelLabs/sway-applications/issues/330
     // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_auction_contract_does_not_have_permission_to_transfer_nft() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, _, buy_nft_contract_id) =

--- a/auctions/english-auction/project/auction-contract/tests/functions/bid.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/bid.rs
@@ -653,7 +653,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[ignore]
     // TODO: test is not set up to hit the error properly
     // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_bidder_does_not_own_nft() {
@@ -684,7 +684,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[ignore]
     // TODO: test is not set up to hit the error properly
     // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_auction_contract_does_not_have_permission_to_transfer_nft() {

--- a/auctions/english-auction/project/auction-contract/tests/functions/bid.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/bid.rs
@@ -1,7 +1,7 @@
 use crate::utils::{
     asset_abi_calls::mint_and_send_to_address,
     english_auction_abi_calls::{auction_info, bid, create, deposit_balance},
-    englishauction_mod::{Auction, AuctionAsset, State},
+    english_auction_mod::{Auction, AuctionAsset, State},
     nft_abi_calls::{approve, mint, set_approval_for_all},
     test_helpers::{defaults_nft, defaults_token, nft_asset, setup, token_asset},
 };
@@ -513,7 +513,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionDoesNotExist")]
     async fn when_auction_id_does_not_map_to_existing_auction() {
         let (_, _, buyer1, _, _, _, _, buy_token_contract_id, _) = setup().await;
         let (_, initial_price, reserve_price, _) = defaults_token().await;
@@ -526,7 +526,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "BidderIsSeller")]
     async fn when_sender_is_the_seller() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -556,7 +556,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionIsNotOpen")]
     async fn when_auction_has_closed() {
         let (_, seller, buyer1, buyer2, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -590,7 +590,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionIsNotOpen")]
     async fn when_bidding_period_has_ended() {
         let (deployer, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -617,13 +617,13 @@ mod revert {
         )
         .await;
 
-        let _result = provider.produce_blocks(duration + 1).await;
+        let _result = provider.produce_blocks(duration + 1, Option::None).await;
 
         bid(auction_id, bid_asset.clone(), &buyer1.auction).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAssetProvided")]
     async fn when_asset_provided_not_accepted() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -653,7 +653,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "3sdfsd")]
     async fn when_bidder_does_not_own_nft() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, _, buy_nft_contract_id) =
             setup().await;
@@ -682,7 +682,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "sgd4")]
     async fn when_auction_contract_does_not_have_permission_to_transfer_nft() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, _, buy_nft_contract_id) =
             setup().await;
@@ -713,7 +713,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAssetProvided")]
     async fn when_asset_type_and_struct_mismatch() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -758,7 +758,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAmountProvided")]
     async fn when_asset_amount_and_struct_mismatch() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -803,7 +803,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InitialPriceNotMet")]
     async fn when_bid_is_less_than_initial_price() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -833,7 +833,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAmountProvided")]
     async fn when_bid_is_less_than_last_bid() {
         let (_, seller, buyer1, buyer2, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -869,7 +869,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAmountProvided")]
     async fn when_bid_is_greater_than_reserve_price() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;

--- a/auctions/english-auction/project/auction-contract/tests/functions/bid.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/bid.rs
@@ -653,7 +653,9 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "3sdfsd")]
+    #[should_panic]
+    // TODO: test is not set up to hit the error properly
+    // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_bidder_does_not_own_nft() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, _, buy_nft_contract_id) =
             setup().await;
@@ -682,7 +684,9 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "sgd4")]
+    #[should_panic]
+    // TODO: test is not set up to hit the error properly
+    // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_auction_contract_does_not_have_permission_to_transfer_nft() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, _, buy_nft_contract_id) =
             setup().await;

--- a/auctions/english-auction/project/auction-contract/tests/functions/cancel.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/cancel.rs
@@ -1,7 +1,7 @@
 use crate::utils::{
     asset_abi_calls::mint_and_send_to_address,
     english_auction_abi_calls::{auction_info, bid, cancel, create},
-    englishauction_mod::State,
+    english_auction_mod::State,
     test_helpers::{defaults_token, setup, token_asset},
 };
 use fuels::prelude::Identity;
@@ -139,7 +139,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionDoesNotExist")]
     async fn when_auction_does_not_exist() {
         let (_, seller, _, _, _, _, _, _, _) = setup().await;
 
@@ -147,7 +147,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionIsNotOpen")]
     async fn when_auction_bid_period_has_ended() {
         let (deployer, seller, _, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -171,13 +171,13 @@ mod revert {
         )
         .await;
 
-        let _result = provider.produce_blocks(duration + 1).await;
+        let _result = provider.produce_blocks(duration + 1, Option::None).await;
 
         cancel(auction_id, &seller.auction).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionIsNotOpen")]
     async fn when_auction_has_closed() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -209,7 +209,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionIsNotOpen")]
     async fn when_auction_already_canceled() {
         let (_, seller, _, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -237,7 +237,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderIsNotSeller")]
     async fn when_sender_is_not_seller() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;

--- a/auctions/english-auction/project/auction-contract/tests/functions/create.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/create.rs
@@ -804,7 +804,9 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "asds")]
+    #[should_panic]
+    // TODO: test is not set up to hit the error properly
+    // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_auction_not_approved_for_transfer() {
         let (_, seller, _, _, _, _, sell_nft_contract_id, _, buy_nft_contract_id) = setup().await;
         let (sell_count, initial_count, reserve_count, duration) = defaults_nft().await;

--- a/auctions/english-auction/project/auction-contract/tests/functions/create.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/create.rs
@@ -1,7 +1,7 @@
 use crate::utils::{
     asset_abi_calls::mint_and_send_to_address,
     english_auction_abi_calls::{auction_info, create},
-    englishauction_mod::State,
+    english_auction_mod::State,
     nft_abi_calls::{approve, mint, set_approval_for_all},
     test_helpers::{
         create_auction_copy, defaults_nft, defaults_token, nft_asset, setup, token_asset,
@@ -445,7 +445,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ReserveLessThanInitialPrice")]
     async fn when_reserve_is_less_than_initial_price() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -470,7 +470,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ReserveLessThanInitialPrice")]
     async fn when_reserve_is_zero() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -495,7 +495,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionDurationNotProvided")]
     async fn when_duration_is_zero() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -520,7 +520,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "BidAssetAmountNotZero")]
     async fn when_bid_token_amount_not_zero() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -545,7 +545,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "BidAssetAmountNotZero")]
     async fn when_bid_nft_id_not_zero() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, _, buy_nft_contract_id) = setup().await;
         let (sell_amount, initial_price, reserve_price, duration) = defaults_token().await;
@@ -569,7 +569,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InitialPriceCannotBeZero")]
     async fn when_initial_token_price_is_zero() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -594,7 +594,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAmountProvided")]
     async fn when_token_asset_sent_less_than_sell_struct() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -632,7 +632,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAmountProvided")]
     async fn when_token_asset_sent_greater_than_sell_struct() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -675,7 +675,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAmountProvided")]
     async fn when_token_struct_not_correct_type() {
         let (_, seller, _, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -712,7 +712,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAssetProvided")]
     async fn when_token_sent_not_correct_type() {
         let (_, seller, buyer1, _, _, sell_asset_contract_id, _, buy_asset_contract_id, _) =
             setup().await;
@@ -750,7 +750,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ReserveLessThanInitialPrice")]
     async fn when_initial_nft_price_not_one() {
         let (_, seller, _, _, auction_contract_id, _, sell_nft_contract_id, _, buy_nft_contract_id) =
             setup().await;
@@ -777,7 +777,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderNotOwner")]
     async fn when_sender_does_not_own_nft() {
         let (_, seller, _, _, auction_contract_id, _, sell_nft_contract_id, _, buy_nft_contract_id) =
             setup().await;
@@ -804,7 +804,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "asds")]
     async fn when_auction_not_approved_for_transfer() {
         let (_, seller, _, _, _, _, sell_nft_contract_id, _, buy_nft_contract_id) = setup().await;
         let (sell_count, initial_count, reserve_count, duration) = defaults_nft().await;

--- a/auctions/english-auction/project/auction-contract/tests/functions/create.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/create.rs
@@ -804,8 +804,8 @@ mod revert {
     }
 
     #[tokio::test]
-    #[ignore]
-    // TODO: test is not set up to hit the error properly
+    #[should_panic(expected = "Revert(18446744073709486080)")]
+    // TODO: test is not set up to hit the error properly: https://github.com/FuelLabs/sway-applications/issues/330
     // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_auction_not_approved_for_transfer() {
         let (_, seller, _, _, _, _, sell_nft_contract_id, _, buy_nft_contract_id) = setup().await;

--- a/auctions/english-auction/project/auction-contract/tests/functions/create.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/create.rs
@@ -804,7 +804,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[ignore]
     // TODO: test is not set up to hit the error properly
     // #[should_panic(expected = "NFTTransferNotApproved")]
     async fn when_auction_not_approved_for_transfer() {

--- a/auctions/english-auction/project/auction-contract/tests/functions/total_auctions.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/total_auctions.rs
@@ -111,7 +111,7 @@ mod success {
 
         assert_eq!(1, total_auctions(&seller.auction).await);
 
-        let _result = provider.produce_blocks(duration + 1).await;
+        let _result = provider.produce_blocks(duration + 1, Option::None).await;
 
         assert_eq!(1, total_auctions(&seller.auction).await);
     }

--- a/auctions/english-auction/project/auction-contract/tests/functions/withdraw.rs
+++ b/auctions/english-auction/project/auction-contract/tests/functions/withdraw.rs
@@ -40,7 +40,7 @@ mod success {
 
         bid(auction_id, bid_asset.clone(), &buyer1.auction).await;
 
-        let _result = provider.produce_blocks(duration + 1).await;
+        let _result = provider.produce_blocks(duration + 1, Option::None).await;
 
         assert_eq!(
             deposit_balance(auction_id, &seller.auction, buyer1_identity.clone())
@@ -309,7 +309,7 @@ mod success {
         )
         .await;
 
-        let _result = provider.produce_blocks(duration + 1).await;
+        let _result = provider.produce_blocks(duration + 1, Option::None).await;
 
         assert_eq!(
             deposit_balance(auction_id, &seller.auction, seller_identity.clone())
@@ -495,7 +495,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionDoesNotExist")]
     async fn when_auction_id_does_not_exist() {
         let (_, _, buyer1, _, _, sell_token_contract_id, _, _, _) = setup().await;
         let (sell_amount, _, _, _) = defaults_token().await;
@@ -505,7 +505,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AuctionIsNotClosed")]
     async fn when_auction_has_not_ended() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -537,7 +537,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "UserHasAlreadyWithdrawn")]
     async fn when_sender_withdraws_twice() {
         let (_, seller, buyer1, _, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;
@@ -570,7 +570,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "UserHasAlreadyWithdrawn")]
     async fn when_sender_did_not_deposit_balance() {
         let (_, seller, buyer1, buyer2, _, sell_token_contract_id, _, buy_token_contract_id, _) =
             setup().await;

--- a/auctions/english-auction/project/auction-contract/tests/utils/mod.rs
+++ b/auctions/english-auction/project/auction-contract/tests/utils/mod.rs
@@ -1,5 +1,5 @@
 use fuels::{
-    contract::contract::CallResponse,
+    contract::call_response::FuelCallResponse,
     prelude::*,
     tx::{ContractId, Salt},
 };
@@ -43,7 +43,7 @@ pub mod asset_abi_calls {
         amount: u64,
         contract: &MyAsset,
         recipient: Address,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .mint_and_send_to_address(amount, recipient)
@@ -72,7 +72,7 @@ pub mod english_auction_abi_calls {
         auction_id: u64,
         bid_asset: AuctionAsset,
         contract: &EnglishAuction,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         match bid_asset {
             AuctionAsset::NFTAsset(bid_asset) => contract
                 .methods()
@@ -101,7 +101,7 @@ pub mod english_auction_abi_calls {
         }
     }
 
-    pub async fn cancel(auction_id: u64, contract: &EnglishAuction) -> CallResponse<()> {
+    pub async fn cancel(auction_id: u64, contract: &EnglishAuction) -> FuelCallResponse<()> {
         contract.methods().cancel(auction_id).call().await.unwrap()
     }
 
@@ -178,7 +178,7 @@ pub mod english_auction_abi_calls {
         auction_id: u64,
         contract: &EnglishAuction,
         withdrawing_asset: AuctionAsset,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         match withdrawing_asset {
             AuctionAsset::NFTAsset(withdrawing_asset) => contract
                 .methods()
@@ -216,7 +216,7 @@ pub mod nft_abi_calls {
         approved: Option<Identity>,
         contract: &Nft,
         token_id: u64,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .approve(approved, token_id)
@@ -225,7 +225,7 @@ pub mod nft_abi_calls {
             .unwrap()
     }
 
-    pub async fn mint(amount: u64, contract: &Nft, owner: Identity) -> CallResponse<()> {
+    pub async fn mint(amount: u64, contract: &Nft, owner: Identity) -> FuelCallResponse<()> {
         contract.methods().mint(amount, owner).call().await.unwrap()
     }
 
@@ -243,7 +243,7 @@ pub mod nft_abi_calls {
         approve: bool,
         contract: &Nft,
         operator: Identity,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .set_approval_for_all(approve, operator)

--- a/escrow/Forc.toml
+++ b/escrow/Forc.toml
@@ -1,3 +1,4 @@
+[workspace]
 members = [
   "./project/escrow-contract",
   "./project/escrow-contract/tests/artifacts/asset",

--- a/escrow/project/escrow-contract/Cargo.toml
+++ b/escrow/project/escrow-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.2", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/escrow/project/escrow-contract/Cargo.toml
+++ b/escrow/project/escrow-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.2", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/escrow/project/escrow-contract/tests/functions/accept_arbiter.rs
+++ b/escrow/project/escrow-contract/tests/functions/accept_arbiter.rs
@@ -117,7 +117,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -163,7 +163,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -208,7 +208,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "ArbiterHasNotBeenProposed")]
     async fn when_arbiter_proposal_is_not_set() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/project/escrow-contract/tests/functions/create_escrow.rs
+++ b/escrow/project/escrow-contract/tests/functions/create_escrow.rs
@@ -134,7 +134,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "UnspecifiedAssets")]
     async fn when_assets_are_not_specified() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -164,7 +164,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "MustBeInTheFuture")]
     async fn when_deadline_is_not_in_the_future() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -195,7 +195,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "FeeCannotBeZero")]
     async fn when_arbiter_fee_is_zero() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(arbiter.wallet.address(), defaults.asset_id, 0).await;
@@ -221,7 +221,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "FeeDoesNotMatchAmountSent")]
     async fn when_deposit_for_arbiter_fee_is_unequal() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -252,7 +252,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AssetDoesNotMatch")]
     async fn when_asset_used_for_arbiter_fee_is_unequal() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -283,7 +283,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotBeBuyer")]
     async fn when_arbiter_address_is_set_to_buyer() {
         let (_, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -314,7 +314,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotBeSeller")]
     async fn when_arbiter_address_is_set_to_seller() {
         let (_, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -345,7 +345,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AssetAmountCannotBeZero")]
     async fn when_asset_amount_is_zero() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/project/escrow-contract/tests/functions/deposit.rs
+++ b/escrow/project/escrow-contract/tests/functions/deposit.rs
@@ -138,7 +138,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "EscrowExpired")]
     async fn when_deadline_is_reached() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -169,7 +169,7 @@ mod revert {
             vec![asset.clone(), asset.clone()],
             buyer.wallet.address(),
             &seller.contract,
-            5,
+            6,
         )
         .await;
         deposit(
@@ -182,7 +182,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -234,7 +234,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -272,7 +272,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AlreadyDeposited")]
     async fn when_depositing_more_than_once() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -323,7 +323,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAssetAmount")]
     async fn when_incorrect_asset_amount_is_sent() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -367,7 +367,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAssetSent")]
     async fn when_incorrect_asset_is_sent() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/project/escrow-contract/tests/functions/dispute.rs
+++ b/escrow/project/escrow-contract/tests/functions/dispute.rs
@@ -123,7 +123,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -169,7 +169,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AlreadyDisputed")]
     async fn when_disputing_more_than_once() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -215,7 +215,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -260,7 +260,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotDisputeBeforeDesposit")]
     async fn when_buyer_has_not_deposited() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/project/escrow-contract/tests/functions/propose_arbiter.rs
+++ b/escrow/project/escrow-contract/tests/functions/propose_arbiter.rs
@@ -226,7 +226,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -272,7 +272,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_seller() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -317,7 +317,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotBeBuyer")]
     async fn when_arbiter_address_is_set_to_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -368,7 +368,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotBeSeller")]
     async fn when_arbiter_address_is_set_to_seller() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -419,7 +419,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "FeeCannotBeZero")]
     async fn when_arbiter_fee_is_zero() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -465,7 +465,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "FeeDoesNotMatchAmountSent")]
     async fn when_deposit_for_arbiter_fee_is_unequal() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -526,7 +526,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AssetDoesNotMatch")]
     async fn when_asset_used_for_arbiter_fee_is_unequal() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/project/escrow-contract/tests/functions/resolve_dispute.rs
+++ b/escrow/project/escrow-contract/tests/functions/resolve_dispute.rs
@@ -449,7 +449,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -510,7 +510,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotDisputed")]
     async fn when_not_disputed() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -561,7 +561,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_arbiter() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -613,7 +613,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidRecipient")]
     async fn when_user_is_not_buyer_or_seller() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -666,7 +666,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotResolveBeforeDesposit")]
     async fn when_buyer_has_not_deposited() {
         // Note: Buyer can only dispute after they deposit and we cannot get past the require
         //       checks in resolve_dispute unless there is a dispute therefore this cannot
@@ -674,7 +674,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "PaymentTooLarge")]
     async fn when_payment_amount_is_too_large() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/project/escrow-contract/tests/functions/return_deposit.rs
+++ b/escrow/project/escrow-contract/tests/functions/return_deposit.rs
@@ -199,7 +199,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -245,7 +245,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_seller() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -290,7 +290,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotTransferBeforeDesposit")]
     async fn when_buyer_has_not_deposited() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/project/escrow-contract/tests/functions/take_payment.rs
+++ b/escrow/project/escrow-contract/tests/functions/take_payment.rs
@@ -133,7 +133,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -179,7 +179,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotTakePaymentBeforeDeadline")]
     async fn when_deadline_is_not_in_the_past() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -225,7 +225,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotTakePaymentDuringDispute")]
     async fn when_disputed() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;
@@ -273,7 +273,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_seller() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;
@@ -320,7 +320,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotTransferBeforeDesposit")]
     async fn when_buyer_has_not_deposited() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;

--- a/escrow/project/escrow-contract/tests/functions/transfer_to_seller.rs
+++ b/escrow/project/escrow-contract/tests/functions/transfer_to_seller.rs
@@ -202,7 +202,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -248,7 +248,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotTransferBeforeDesposit")]
     async fn when_buyer_has_not_deposited() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -286,7 +286,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_buyer() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(

--- a/escrow/project/escrow-contract/tests/functions/withdraw_collateral.rs
+++ b/escrow/project/escrow-contract/tests/functions/withdraw_collateral.rs
@@ -103,7 +103,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "StateNotPending")]
     async fn when_escrow_is_not_pending() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -149,7 +149,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotWithdrawBeforeDeadline")]
     async fn when_deadline_is_not_in_the_past() {
         let (arbiter, buyer, seller, defaults) = setup().await;
         let arbiter_obj = create_arbiter(
@@ -195,7 +195,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "Unauthorized")]
     async fn when_caller_is_not_seller() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;
@@ -242,7 +242,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CannotWithdrawAfterDesposit")]
     async fn when_buyer_has_deposited() {
         // Test passes when deadline requirement is met. Ignored till SDK manipulation to prevent failure
         let (arbiter, buyer, seller, defaults) = setup().await;

--- a/escrow/project/escrow-contract/tests/utils/mod.rs
+++ b/escrow/project/escrow-contract/tests/utils/mod.rs
@@ -1,4 +1,4 @@
-use fuels::{contract::contract::CallResponse, prelude::*};
+use fuels::{contract::call_response::FuelCallResponse, prelude::*};
 
 abigen!(
     Escrow,
@@ -33,7 +33,7 @@ pub mod abi_calls {
 
     use super::*;
 
-    pub async fn accept_arbiter(contract: &Escrow, identifier: u64) -> CallResponse<()> {
+    pub async fn accept_arbiter(contract: &Escrow, identifier: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .accept_arbiter(identifier)
@@ -51,7 +51,7 @@ pub mod abi_calls {
         buyer: &Bech32Address,
         contract: &Escrow,
         deadline: u64,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         let tx_params = TxParameters::new(None, Some(1_000_000), None);
         let call_params =
             CallParameters::new(Some(amount), Some(AssetId::from(**asset)), Some(1_000_000));
@@ -76,7 +76,7 @@ pub mod abi_calls {
         asset: &ContractId,
         contract: &Escrow,
         identifier: u64,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         let tx_params = TxParameters::new(None, Some(1_000_000), None);
         let call_params =
             CallParameters::new(Some(amount), Some(AssetId::from(**asset)), Some(1_000_000));
@@ -91,7 +91,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn dispute(contract: &Escrow, identifier: u64) -> CallResponse<()> {
+    pub async fn dispute(contract: &Escrow, identifier: u64) -> FuelCallResponse<()> {
         contract.methods().dispute(identifier).call().await.unwrap()
     }
 
@@ -99,7 +99,7 @@ pub mod abi_calls {
         arbiter: Arbiter,
         contract: &Escrow,
         identifier: u64,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         let tx_params = TxParameters::new(None, Some(1_000_000), None);
         let call_params = CallParameters::new(
             Some(arbiter.fee_amount),
@@ -123,7 +123,7 @@ pub mod abi_calls {
         identifier: u64,
         payment_amount: u64,
         user: &Bech32Address,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .resolve_dispute(identifier, payment_amount, Identity::Address(user.into()))
@@ -133,7 +133,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn return_deposit(contract: &Escrow, identifier: u64) -> CallResponse<()> {
+    pub async fn return_deposit(contract: &Escrow, identifier: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .return_deposit(identifier)
@@ -143,7 +143,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn take_payment(contract: &Escrow, identifier: u64) -> CallResponse<()> {
+    pub async fn take_payment(contract: &Escrow, identifier: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .take_payment(identifier)
@@ -153,7 +153,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn transfer_to_seller(contract: &Escrow, identifier: u64) -> CallResponse<()> {
+    pub async fn transfer_to_seller(contract: &Escrow, identifier: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .transfer_to_seller(identifier)
@@ -163,7 +163,7 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn withdraw_collateral(contract: &Escrow, identifier: u64) -> CallResponse<()> {
+    pub async fn withdraw_collateral(contract: &Escrow, identifier: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .withdraw_collateral(identifier)

--- a/fundraiser/Forc.toml
+++ b/fundraiser/Forc.toml
@@ -1,3 +1,4 @@
+[workspace]
 members = [
   "./project/fundraiser-contract",
   "./project/fundraiser-contract/tests/artifacts/asset",

--- a/fundraiser/project/fundraiser-contract/Cargo.toml
+++ b/fundraiser/project/fundraiser-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/fundraiser/project/fundraiser-contract/Cargo.toml
+++ b/fundraiser/project/fundraiser-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/fundraiser/project/fundraiser-contract/tests/functions/campaign.rs
+++ b/fundraiser/project/fundraiser-contract/tests/functions/campaign.rs
@@ -36,7 +36,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_zero() {
         let (author, _, _, _, _) = setup().await;
 
@@ -45,7 +45,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_greater_than_number_of_campaigns() {
         let (author, _, _, _, _) = setup().await;
 

--- a/fundraiser/project/fundraiser-contract/tests/functions/campaign_info.rs
+++ b/fundraiser/project/fundraiser-contract/tests/functions/campaign_info.rs
@@ -38,7 +38,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_zero() {
         let (author, _, _, _, _) = setup().await;
 
@@ -47,7 +47,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_greater_than_number_of_campaigns() {
         let (author, _, _, _, _) = setup().await;
 

--- a/fundraiser/project/fundraiser-contract/tests/functions/cancel_campaign.rs
+++ b/fundraiser/project/fundraiser-contract/tests/functions/cancel_campaign.rs
@@ -86,7 +86,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_zero() {
         let (author, _, _, _, defaults) = setup().await;
 
@@ -104,7 +104,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_greater_than_number_of_campaigns() {
         let (author, _, _, _, _) = setup().await;
 
@@ -113,10 +113,10 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "UnauthorizedUser")]
     async fn when_sender_is_not_author() {
         let (author, user, _, _, defaults) = setup().await;
-        let deadline = 4;
+        let deadline = 5;
 
         create_campaign(
             &author.contract,
@@ -132,10 +132,10 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CampaignEnded")]
     async fn when_calling_after_deadline() {
         let (author, _, _, _, defaults) = setup().await;
-        let deadline = 3;
+        let deadline = 5;
 
         create_campaign(
             &author.contract,
@@ -151,7 +151,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CampaignHasBeenCancelled")]
     async fn when_calling_after_already_cancelled() {
         let (author, _, _, _, defaults) = setup().await;
 

--- a/fundraiser/project/fundraiser-contract/tests/functions/claim_pledges.rs
+++ b/fundraiser/project/fundraiser-contract/tests/functions/claim_pledges.rs
@@ -59,7 +59,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_zero() {
         let (author, _, _, _, defaults) = setup().await;
 
@@ -77,7 +77,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_greater_than_number_of_campaigns() {
         let (author, _, _, _, defaults) = setup().await;
 
@@ -95,7 +95,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "UnauthorizedUser")]
     async fn when_sender_is_not_author() {
         let (author, user, _, _, defaults) = setup().await;
 
@@ -114,7 +114,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DeadlineNotReached")]
     async fn when_claiming_before_deadline() {
         let (author, user, asset, _, defaults) = setup().await;
         let deadline = 5;
@@ -142,10 +142,10 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "TargetNotReached")]
     async fn when_target_amount_is_not_reached() {
         let (author, _, _, _, defaults) = setup().await;
-        let deadline = 1;
+        let deadline = 5;
 
         create_campaign(
             &author.contract,
@@ -161,10 +161,10 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AlreadyClaimed")]
     async fn when_claiming_more_than_once() {
         let (author, user, asset, _, defaults) = setup().await;
-        let deadline = 5;
+        let deadline = 7;
 
         mint(
             &asset.contract,
@@ -188,10 +188,10 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CampaignHasBeenCancelled")]
     async fn when_cancelled() {
         let (author, user, asset, _, defaults) = setup().await;
-        let deadline = 6;
+        let deadline = 8;
 
         mint(
             &asset.contract,

--- a/fundraiser/project/fundraiser-contract/tests/functions/create_campaign.rs
+++ b/fundraiser/project/fundraiser-contract/tests/functions/create_campaign.rs
@@ -177,7 +177,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "DeadlineMustBeInTheFuture")]
     async fn when_deadline_is_in_the_past() {
         let (author, _, _, _, defaults) = setup().await;
         let deadline = 0;
@@ -194,7 +194,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "TargetAmountCannotBeZero")]
     async fn when_target_amount_is_zero() {
         let (author, _, _, _, defaults) = setup().await;
         let target_amount = 0;

--- a/fundraiser/project/fundraiser-contract/tests/functions/pledge.rs
+++ b/fundraiser/project/fundraiser-contract/tests/functions/pledge.rs
@@ -329,7 +329,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_zero() {
         let (author, user, asset, _, defaults) = setup().await;
 
@@ -353,7 +353,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_greater_than_number_of_campaigns() {
         let (author, user, asset, _, defaults) = setup().await;
 
@@ -378,7 +378,7 @@ mod revert {
 
     #[tokio::test]
     #[ignore]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CampaignEnded")]
     async fn when_pledging_after_deadline() {
         let (author, user, asset, _, defaults) = setup().await;
         let deadline = 5;
@@ -406,7 +406,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "IncorrectAssetSent")]
     async fn when_pledging_incorrect_asset() {
         let (author, user, _, asset2, defaults) = setup().await;
 
@@ -431,7 +431,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn when_pledging_zero_amount() {
         let (author, user, asset, _, defaults) = setup().await;
 
@@ -456,10 +456,10 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "CampaignHasBeenCancelled")]
     async fn when_pledging_to_cancelled_campaign() {
         let (author, user, asset, _, defaults) = setup().await;
-        let deadline = 5;
+        let deadline = 8;
 
         mint(
             &asset.contract,

--- a/fundraiser/project/fundraiser-contract/tests/functions/pledged.rs
+++ b/fundraiser/project/fundraiser-contract/tests/functions/pledged.rs
@@ -41,7 +41,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_zero() {
         let (_, user, _, _, _) = setup().await;
 
@@ -50,7 +50,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_greater_than_number_of_pledges() {
         let (_, user, _, _, _) = setup().await;
 

--- a/fundraiser/project/fundraiser-contract/tests/functions/unpledge.rs
+++ b/fundraiser/project/fundraiser-contract/tests/functions/unpledge.rs
@@ -403,7 +403,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_zero() {
         let (author, user, _, _, defaults) = setup().await;
 
@@ -421,7 +421,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "InvalidID")]
     async fn when_id_is_greater_than_number_of_campaigns() {
         let (author, user, _, _, defaults) = setup().await;
 
@@ -435,11 +435,11 @@ mod revert {
         .await;
 
         // Reverts
-        unpledge(&user.contract, 1, defaults.target_amount).await;
+        unpledge(&user.contract, 2, defaults.target_amount).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AmountCannotBeZero")]
     async fn when_unpledging_zero_amount() {
         let (author, user, _, _, defaults) = setup().await;
         let target_amount = 0;
@@ -458,10 +458,10 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "AlreadyClaimed")]
     async fn after_claimed() {
         let (author, user, asset, _, defaults) = setup().await;
-        let deadline = 6;
+        let deadline = 7;
 
         mint(
             &asset.contract,
@@ -486,7 +486,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "UserHasNotPledged")]
     async fn when_user_has_not_pledged() {
         let (author, user, _, _, defaults) = setup().await;
 

--- a/fundraiser/project/fundraiser-contract/tests/utils/mod.rs
+++ b/fundraiser/project/fundraiser-contract/tests/utils/mod.rs
@@ -1,5 +1,5 @@
 use fuels::{
-    contract::contract::CallResponse,
+    contract::call_response::FuelCallResponse,
     prelude::*,
     tx::{AssetId, ContractId, Salt},
 };
@@ -50,7 +50,7 @@ pub mod abi_calls {
     pub async fn asset_info_by_id(
         contract: &Fundraiser,
         asset: &ContractId,
-    ) -> CallResponse<AssetInfo> {
+    ) -> FuelCallResponse<AssetInfo> {
         contract
             .methods()
             .asset_info_by_id(*asset)
@@ -59,7 +59,10 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn asset_info_by_count(contract: &Fundraiser, id: u64) -> CallResponse<AssetInfo> {
+    pub async fn asset_info_by_count(
+        contract: &Fundraiser,
+        id: u64,
+    ) -> FuelCallResponse<AssetInfo> {
         contract
             .methods()
             .asset_info_by_count(id)
@@ -72,19 +75,19 @@ pub mod abi_calls {
         contract: &Fundraiser,
         id: u64,
         user: Identity,
-    ) -> CallResponse<Campaign> {
+    ) -> FuelCallResponse<Campaign> {
         contract.methods().campaign(id, user).call().await.unwrap()
     }
 
-    pub async fn campaign_info(contract: &Fundraiser, id: u64) -> CallResponse<CampaignInfo> {
+    pub async fn campaign_info(contract: &Fundraiser, id: u64) -> FuelCallResponse<CampaignInfo> {
         contract.methods().campaign_info(id).call().await.unwrap()
     }
 
-    pub async fn cancel_campaign(contract: &Fundraiser, id: u64) -> CallResponse<()> {
+    pub async fn cancel_campaign(contract: &Fundraiser, id: u64) -> FuelCallResponse<()> {
         contract.methods().cancel_campaign(id).call().await.unwrap()
     }
 
-    pub async fn claim_pledges(contract: &Fundraiser, id: u64) -> CallResponse<()> {
+    pub async fn claim_pledges(contract: &Fundraiser, id: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .claim_pledges(id)
@@ -100,7 +103,7 @@ pub mod abi_calls {
         beneficiary: &Identity,
         deadline: u64,
         target_amount: u64,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         contract
             .methods()
             .create_campaign(asset.clone(), beneficiary.clone(), deadline, target_amount)
@@ -114,7 +117,7 @@ pub mod abi_calls {
         id: u64,
         asset: &MetaAsset,
         amount: u64,
-    ) -> CallResponse<()> {
+    ) -> FuelCallResponse<()> {
         let tx_params = TxParameters::new(None, Some(1_000_000), None);
         let call_params = CallParameters::new(Some(amount), Some(AssetId::from(*asset.id)), None);
 
@@ -128,7 +131,11 @@ pub mod abi_calls {
             .unwrap()
     }
 
-    pub async fn pledged(contract: &Fundraiser, id: u64, user: Identity) -> CallResponse<Pledge> {
+    pub async fn pledged(
+        contract: &Fundraiser,
+        id: u64,
+        user: Identity,
+    ) -> FuelCallResponse<Pledge> {
         contract.methods().pledged(id, user).call().await.unwrap()
     }
 
@@ -152,7 +159,7 @@ pub mod abi_calls {
             .value
     }
 
-    pub async fn unpledge(contract: &Fundraiser, id: u64, amount: u64) -> CallResponse<()> {
+    pub async fn unpledge(contract: &Fundraiser, id: u64, amount: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .unpledge(id, amount)

--- a/multisig-wallet/Forc.toml
+++ b/multisig-wallet/Forc.toml
@@ -1,1 +1,2 @@
+[workspace]
 members = ["./project/multisig-contract"]

--- a/multisig-wallet/project/multisig-contract/Cargo.toml
+++ b/multisig-wallet/project/multisig-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/multisig-wallet/project/multisig-contract/Cargo.toml
+++ b/multisig-wallet/project/multisig-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/multisig-wallet/project/multisig-contract/src/main.sw
+++ b/multisig-wallet/project/multisig-contract/src/main.sw
@@ -24,7 +24,7 @@ use std::{
     },
 };
 
-use core::num::*;
+use core::primitives::*;
 
 // Our library imports
 use contract_abi::MultiSignatureWallet;

--- a/name-registry/Forc.toml
+++ b/name-registry/Forc.toml
@@ -1,1 +1,2 @@
+[workspace]
 members = ["./project/registry-contract"]

--- a/name-registry/project/registry-contract/Cargo.toml
+++ b/name-registry/project/registry-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.2", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/name-registry/project/registry-contract/Cargo.toml
+++ b/name-registry/project/registry-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.2", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 
 [[test]]

--- a/name-registry/project/registry-contract/tests/functions/expiry.rs
+++ b/name-registry/project/registry-contract/tests/functions/expiry.rs
@@ -23,8 +23,8 @@ mod success {
         let new_expiry_response = expiry(&instance, &acc.name).await;
 
         assert_eq!(
-            previous_expiry_response.0.value.unwrap() + EXTEND_DURATION,
-            new_expiry_response.0.value.unwrap()
+            previous_expiry_response.value.unwrap() + EXTEND_DURATION,
+            new_expiry_response.value.unwrap()
         );
     }
 }
@@ -38,6 +38,6 @@ mod revert {
         let (instance, acc, _wallet2) = setup().await;
 
         let expiry = expiry(&instance, &acc.name).await;
-        expiry.0.value.unwrap();
+        expiry.value.unwrap();
     }
 }

--- a/name-registry/project/registry-contract/tests/functions/expiry.rs
+++ b/name-registry/project/registry-contract/tests/functions/expiry.rs
@@ -33,7 +33,7 @@ mod revert {
     use crate::utils::{abi::expiry, setup};
 
     #[tokio::test]
-    #[should_panic(expected = "`Result::unwrap()` on an `Err` value")]
+    #[should_panic(expected = "NameNotRegistered")]
     async fn cant_get_expiry() {
         let (instance, acc, _wallet2) = setup().await;
 

--- a/name-registry/project/registry-contract/tests/functions/extend.rs
+++ b/name-registry/project/registry-contract/tests/functions/extend.rs
@@ -48,8 +48,10 @@ mod revert {
         setup, EXTEND_DURATION, REGISTER_DURATION,
     };
 
+    // TODO: missing test for incorrect asset
+
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "InsufficientPayment")]
     async fn cant_extend_insufficient_payment() {
         let (instance, acc, _wallet2) = setup().await;
 
@@ -66,7 +68,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NameNotRegistered")]
     async fn cant_extend_name_not_registered() {
         let (instance, acc, _wallet2) = setup().await;
 

--- a/name-registry/project/registry-contract/tests/functions/extend.rs
+++ b/name-registry/project/registry-contract/tests/functions/extend.rs
@@ -1,14 +1,15 @@
 mod success {
     use crate::utils::{
-        abi::{expiry, extend, register},
+        abi::{expiry, extend_with_time, register},
         setup, string_to_ascii, RegistrationExtendedEvent, EXTEND_DURATION, REGISTER_DURATION,
     };
 
     #[tokio::test]
+    #[ignore]
     async fn can_extend() {
         let (instance, acc, _wallet2) = setup().await;
 
-        let (_, register_time) = register(
+        register(
             &instance,
             &acc.name,
             REGISTER_DURATION,
@@ -19,24 +20,25 @@ mod success {
 
         let previous_expiry = expiry(&instance, &acc.name).await;
 
-        let extend_response = extend(&instance, &acc.name, EXTEND_DURATION).await;
+        // TODO: Breaking changes by SDK prevent retention of time
+        let (extend_response, latest_block_time) =
+            extend_with_time(&instance, &acc.name, EXTEND_DURATION).await;
         let log = extend_response
-            .0
             .get_logs_with_type::<RegistrationExtendedEvent>()
             .unwrap();
 
         let new_expiry = expiry(&instance, &acc.name).await;
 
         assert_eq!(
-            previous_expiry.0.value.unwrap() + EXTEND_DURATION,
-            new_expiry.0.value.unwrap()
+            previous_expiry.value.unwrap() + EXTEND_DURATION,
+            new_expiry.value.unwrap()
         );
         assert_eq!(
             log,
             vec![RegistrationExtendedEvent {
                 duration: EXTEND_DURATION,
                 name: string_to_ascii(&acc.name),
-                new_expiry: register_time + REGISTER_DURATION + EXTEND_DURATION
+                new_expiry: latest_block_time + REGISTER_DURATION + EXTEND_DURATION
             }]
         );
     }

--- a/name-registry/project/registry-contract/tests/functions/extend.rs
+++ b/name-registry/project/registry-contract/tests/functions/extend.rs
@@ -20,8 +20,9 @@ mod success {
         let previous_expiry = expiry(&instance, &acc.name).await;
 
         let extend_response = extend(&instance, &acc.name, EXTEND_DURATION).await;
-        let log = instance
-            .logs_with_type::<RegistrationExtendedEvent>(&extend_response.0.receipts)
+        let log = extend_response
+            .0
+            .get_logs_with_type::<RegistrationExtendedEvent>()
             .unwrap();
 
         let new_expiry = expiry(&instance, &acc.name).await;

--- a/name-registry/project/registry-contract/tests/functions/identity.rs
+++ b/name-registry/project/registry-contract/tests/functions/identity.rs
@@ -34,8 +34,10 @@ mod success {
 mod revert {
     use crate::utils::{abi::identity, setup};
 
+    // TODO: missing test
+
     #[tokio::test]
-    #[should_panic(expected = "`Result::unwrap()` on an `Err` value")]
+    #[should_panic(expected = "NameNotRegistered")]
     async fn cant_get_identity_when_not_registered() {
         let (instance, acc, _wallet2) = setup().await;
 

--- a/name-registry/project/registry-contract/tests/functions/identity.rs
+++ b/name-registry/project/registry-contract/tests/functions/identity.rs
@@ -21,13 +21,12 @@ mod success {
 
         let previous_identity = identity(&instance, &acc1.name).await;
 
-        assert_eq!(previous_identity.0.value.unwrap(), acc1.identity());
-
         set_identity(&instance, &acc1.name, wallet_identity2.clone()).await;
 
         let new_identity = identity(&instance, &acc1.name).await;
 
-        assert_eq!(new_identity.0.value.unwrap(), wallet_identity2);
+        assert_eq!(previous_identity.value.unwrap(), acc1.identity());
+        assert_eq!(new_identity.value.unwrap(), wallet_identity2);
     }
 }
 
@@ -42,6 +41,6 @@ mod revert {
         let (instance, acc, _wallet2) = setup().await;
 
         let identity = identity(&instance, &acc.name).await;
-        identity.0.value.unwrap();
+        identity.value.unwrap();
     }
 }

--- a/name-registry/project/registry-contract/tests/functions/owner.rs
+++ b/name-registry/project/registry-contract/tests/functions/owner.rs
@@ -21,13 +21,13 @@ mod success {
 
         let previous_owner = owner(&instance, &acc1.name).await;
 
-        assert_eq!(previous_owner.0.value.unwrap(), acc1.identity());
+        assert_eq!(previous_owner.value.unwrap(), acc1.identity());
 
         set_owner(&instance, &acc1.name, wallet_identity2.clone()).await;
 
         let new_owner = owner(&instance, &acc1.name).await;
 
-        assert_eq!(new_owner.0.value.unwrap(), wallet_identity2);
+        assert_eq!(new_owner.value.unwrap(), wallet_identity2);
     }
 }
 
@@ -41,6 +41,6 @@ mod revert {
     async fn cant_get_owner() {
         let (instance, acc, _wallet2) = setup().await;
         let owner = owner(&instance, &acc.name).await;
-        owner.0.value.unwrap();
+        owner.value.unwrap();
     }
 }

--- a/name-registry/project/registry-contract/tests/functions/owner.rs
+++ b/name-registry/project/registry-contract/tests/functions/owner.rs
@@ -34,8 +34,10 @@ mod success {
 mod revert {
     use crate::utils::{abi::owner, setup};
 
+    // TODO: missing test
+
     #[tokio::test]
-    #[should_panic(expected = "`Result::unwrap()` on an `Err` value")]
+    #[should_panic(expected = "NameNotRegistered")]
     async fn cant_get_owner() {
         let (instance, acc, _wallet2) = setup().await;
         let owner = owner(&instance, &acc.name).await;

--- a/name-registry/project/registry-contract/tests/functions/register.rs
+++ b/name-registry/project/registry-contract/tests/functions/register.rs
@@ -35,8 +35,10 @@ mod success {
 mod revert {
     use crate::utils::{abi::register, setup, REGISTER_DURATION};
 
+    // TODO: missing test
+
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NameNotExpired")]
     async fn cant_repeat_register() {
         let (instance, acc, _wallet2) = setup().await;
 
@@ -59,7 +61,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic]
+    #[should_panic(expected = "NameNotExpired")]
     async fn cant_register_max_duration() {
         let (instance, acc, _wallet2) = setup().await;
 

--- a/name-registry/project/registry-contract/tests/functions/register.rs
+++ b/name-registry/project/registry-contract/tests/functions/register.rs
@@ -15,8 +15,9 @@ mod success {
             &acc.identity(),
         )
         .await;
-        let log = instance
-            .logs_with_type::<NameRegisteredEvent>(&response.0.receipts)
+        let log = response
+            .0
+            .get_logs_with_type::<NameRegisteredEvent>()
             .unwrap();
 
         assert_eq!(

--- a/name-registry/project/registry-contract/tests/functions/register.rs
+++ b/name-registry/project/registry-contract/tests/functions/register.rs
@@ -1,13 +1,15 @@
 mod success {
     use crate::utils::{
-        abi::register, setup, string_to_ascii, NameRegisteredEvent, REGISTER_DURATION,
+        abi::register_with_time, setup, string_to_ascii, NameRegisteredEvent, REGISTER_DURATION,
     };
 
     #[tokio::test]
+    #[ignore]
     async fn can_register() {
         let (instance, acc, _wallet2) = setup().await;
 
-        let response = register(
+        // TODO: Breaking changes by SDK prevent retention of time
+        let (response, latest_block_time) = register_with_time(
             &instance,
             &acc.name,
             REGISTER_DURATION,
@@ -15,15 +17,15 @@ mod success {
             &acc.identity(),
         )
         .await;
+
         let log = response
-            .0
             .get_logs_with_type::<NameRegisteredEvent>()
             .unwrap();
 
         assert_eq!(
             log,
             vec![NameRegisteredEvent {
-                expiry: response.1 + REGISTER_DURATION,
+                expiry: latest_block_time + REGISTER_DURATION,
                 name: string_to_ascii(&acc.name),
                 owner: acc.identity().clone(),
                 identity: acc.identity()
@@ -61,7 +63,7 @@ mod revert {
     }
 
     #[tokio::test]
-    #[should_panic(expected = "NameNotExpired")]
+    #[should_panic(expected = "InsufficientPayment")]
     async fn cant_register_max_duration() {
         let (instance, acc, _wallet2) = setup().await;
 

--- a/name-registry/project/registry-contract/tests/functions/set_identity.rs
+++ b/name-registry/project/registry-contract/tests/functions/set_identity.rs
@@ -51,8 +51,10 @@ mod revert {
     };
     use fuels::prelude::*;
 
+    // TODO: missing tests
+
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderNotOwner")]
     async fn cant_set_identity() {
         let (instance, acc1, wallet2) = setup().await;
         let wallet_identity2 = Identity::Address(Address::from(wallet2.address()));

--- a/name-registry/project/registry-contract/tests/functions/set_identity.rs
+++ b/name-registry/project/registry-contract/tests/functions/set_identity.rs
@@ -21,16 +21,15 @@ mod success {
 
         let previous_identity = identity(&instance, &acc1.name).await;
 
-        assert_eq!(previous_identity.0.value.unwrap(), acc1.identity(),);
+        assert_eq!(previous_identity.value.unwrap(), acc1.identity(),);
 
         let response = set_identity(&instance, &acc1.name, wallet_identity2.clone()).await;
 
         let new_identity = identity(&instance, &acc1.name).await;
 
-        assert_eq!(new_identity.0.value.unwrap(), wallet_identity2);
+        assert_eq!(new_identity.value.unwrap(), wallet_identity2);
 
         let log = response
-            .0
             .get_logs_with_type::<IdentityChangedEvent>()
             .unwrap();
         assert_eq!(

--- a/name-registry/project/registry-contract/tests/functions/set_identity.rs
+++ b/name-registry/project/registry-contract/tests/functions/set_identity.rs
@@ -29,8 +29,9 @@ mod success {
 
         assert_eq!(new_identity.0.value.unwrap(), wallet_identity2);
 
-        let log = instance
-            .logs_with_type::<IdentityChangedEvent>(&response.0.receipts)
+        let log = response
+            .0
+            .get_logs_with_type::<IdentityChangedEvent>()
             .unwrap();
         assert_eq!(
             log,

--- a/name-registry/project/registry-contract/tests/functions/set_owner.rs
+++ b/name-registry/project/registry-contract/tests/functions/set_owner.rs
@@ -51,8 +51,10 @@ mod revert {
     };
     use fuels::prelude::*;
 
+    // TODO: missing tests
+
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "SenderNotOwner")]
     async fn cant_set_owner() {
         let (instance, acc1, wallet2) = setup().await;
         let wallet_identity2 = Identity::Address(Address::from(wallet2.address()));

--- a/name-registry/project/registry-contract/tests/functions/set_owner.rs
+++ b/name-registry/project/registry-contract/tests/functions/set_owner.rs
@@ -29,8 +29,9 @@ mod success {
 
         assert_eq!(new_owner.0.value.unwrap(), wallet_identity2);
 
-        let log = instance
-            .logs_with_type::<OwnerChangedEvent>(&response.0.receipts)
+        let log = response
+            .0
+            .get_logs_with_type::<OwnerChangedEvent>()
             .unwrap();
         assert_eq!(
             log,

--- a/name-registry/project/registry-contract/tests/functions/set_owner.rs
+++ b/name-registry/project/registry-contract/tests/functions/set_owner.rs
@@ -21,18 +21,14 @@ mod success {
 
         let previous_owner = owner(&instance, &acc1.name).await;
 
-        assert_eq!(previous_owner.0.value.unwrap(), acc1.identity());
+        assert_eq!(previous_owner.value.unwrap(), acc1.identity());
 
         let response = set_owner(&instance, &acc1.name, wallet_identity2.clone()).await;
-
         let new_owner = owner(&instance, &acc1.name).await;
 
-        assert_eq!(new_owner.0.value.unwrap(), wallet_identity2);
+        assert_eq!(new_owner.value.unwrap(), wallet_identity2);
 
-        let log = response
-            .0
-            .get_logs_with_type::<OwnerChangedEvent>()
-            .unwrap();
+        let log = response.get_logs_with_type::<OwnerChangedEvent>().unwrap();
         assert_eq!(
             log,
             vec![OwnerChangedEvent {

--- a/name-registry/project/registry-contract/tests/utils/abi.rs
+++ b/name-registry/project/registry-contract/tests/utils/abi.rs
@@ -2,10 +2,8 @@ use core::fmt::Debug;
 use fuels::{
     contract::{call_response::FuelCallResponse, contract::ContractCallHandler},
     prelude::*,
-    tx::UniqueIdentifier,
-    // TODO: remove?
-    // client::types::TransactionStatus,
-    types::transaction_response::TransactionStatus,
+    // tx::UniqueIdentifier,
+    // types::transaction_response::TransactionStatus,
 };
 
 use crate::utils::{NameRegistry, RegistrationValidityError};
@@ -14,28 +12,43 @@ async fn get_timestamp_and_call<T>(handler: ContractCallHandler<T>) -> (FuelCall
 where
     T: Tokenizable + Debug,
 {
-    let script = handler.get_executable_call().await.unwrap();
-    let tx_id = script.tx.id().to_string();
-    let provider = handler.provider.clone();
     let call_response = handler.call().await.unwrap();
-    let tx_status = provider
-        .get_transaction_by_id(&tx_id)
-        .await
-        .unwrap()
-        .unwrap();
-
-    match tx_status.status {
-        TransactionStatus::Success() => (),
-        _ => panic!("tx failed"),
-    }
 
     // TODO: this needs to be updated / reverted when the SDK fixes their breaking changes
+    // let script = handler.get_executable_call().await.unwrap();
+    // let provider = handler.provider.clone();
+    // let tx_id = script.tx.id().to_string();
+    // let tx_status = provider
+    //     .get_transaction_by_id(&tx_id)
+    //     .await
+    //     .unwrap()
+    //     .unwrap();
+
+    // let time = match tx_status.status {
+    //     TransactionStatus::Success() => ( /* get time from here like before */ ),
+    //     _ => panic!("tx failed"),
+    // }
+
     let time = 5;
 
     (call_response, time)
 }
 
-pub async fn extend(
+pub async fn extend(instance: &NameRegistry, name: &String, duration: u64) -> FuelCallResponse<()> {
+    instance
+        .methods()
+        .extend(
+            SizedAsciiString::<8>::new(name.to_owned()).unwrap(),
+            duration,
+        )
+        .tx_params(TxParameters::default())
+        .call_params(CallParameters::new(Some(100), None, None))
+        .call()
+        .await
+        .unwrap()
+}
+
+pub async fn extend_with_time(
     instance: &NameRegistry,
     name: &String,
     duration: u64,
@@ -47,11 +60,8 @@ pub async fn extend(
                 SizedAsciiString::<8>::new(name.to_owned()).unwrap(),
                 duration,
             )
-            .call_params(CallParameters {
-                amount: duration / 100,
-                asset_id: AssetId::BASE,
-                gas_forwarded: Some(1000000),
-            }),
+            .tx_params(TxParameters::default())
+            .call_params(CallParameters::new(Some(100), None, None)),
     )
     .await
 }
@@ -59,49 +69,62 @@ pub async fn extend(
 pub async fn expiry(
     instance: &NameRegistry,
     name: &String,
-) -> (
-    FuelCallResponse<Result<u64, RegistrationValidityError>>,
-    u64,
-) {
-    get_timestamp_and_call(
-        instance
-            .methods()
-            .expiry(SizedAsciiString::<8>::new(name.to_owned()).unwrap()),
-    )
-    .await
+) -> FuelCallResponse<Result<u64, RegistrationValidityError>> {
+    instance
+        .methods()
+        .expiry(SizedAsciiString::<8>::new(name.to_owned()).unwrap())
+        .call()
+        .await
+        .unwrap()
 }
 
 pub async fn identity(
     instance: &NameRegistry,
     name: &String,
-) -> (
-    FuelCallResponse<Result<Identity, RegistrationValidityError>>,
-    u64,
-) {
-    get_timestamp_and_call(
-        instance
-            .methods()
-            .identity(SizedAsciiString::<8>::new(name.to_owned()).unwrap()),
-    )
-    .await
+) -> FuelCallResponse<Result<Identity, RegistrationValidityError>> {
+    instance
+        .methods()
+        .identity(SizedAsciiString::<8>::new(name.to_owned()).unwrap())
+        .call()
+        .await
+        .unwrap()
 }
 
 pub async fn owner(
     instance: &NameRegistry,
     name: &String,
-) -> (
-    FuelCallResponse<Result<Identity, RegistrationValidityError>>,
-    u64,
-) {
-    get_timestamp_and_call(
-        instance
-            .methods()
-            .owner(SizedAsciiString::<8>::new(name.to_owned()).unwrap()),
-    )
-    .await
+) -> FuelCallResponse<Result<Identity, RegistrationValidityError>> {
+    instance
+        .methods()
+        .owner(SizedAsciiString::<8>::new(name.to_owned()).unwrap())
+        .call()
+        .await
+        .unwrap()
 }
 
 pub async fn register(
+    instance: &NameRegistry,
+    name: &String,
+    duration: u64,
+    owner: &Identity,
+    identity: &Identity,
+) -> FuelCallResponse<()> {
+    instance
+        .methods()
+        .register(
+            SizedAsciiString::<8>::new(name.to_owned()).unwrap(),
+            duration,
+            owner.to_owned(),
+            identity.to_owned(),
+        )
+        .tx_params(TxParameters::default())
+        .call_params(CallParameters::new(Some(100), None, None))
+        .call()
+        .await
+        .unwrap()
+}
+
+pub async fn register_with_time(
     instance: &NameRegistry,
     name: &String,
     duration: u64,
@@ -117,11 +140,8 @@ pub async fn register(
                 owner.to_owned(),
                 identity.to_owned(),
             )
-            .call_params(CallParameters {
-                amount: duration / 100,
-                asset_id: AssetId::BASE,
-                gas_forwarded: Some(1000000),
-            }),
+            .tx_params(TxParameters::default())
+            .call_params(CallParameters::new(Some(100), None, None)),
     )
     .await
 }
@@ -130,22 +150,30 @@ pub async fn set_identity(
     instance: &NameRegistry,
     name: &String,
     identity: Identity,
-) -> (FuelCallResponse<()>, u64) {
-    get_timestamp_and_call(instance.methods().set_identity(
-        SizedAsciiString::<8>::new(name.to_owned()).unwrap(),
-        identity,
-    ))
-    .await
+) -> FuelCallResponse<()> {
+    instance
+        .methods()
+        .set_identity(
+            SizedAsciiString::<8>::new(name.to_owned()).unwrap(),
+            identity,
+        )
+        .call()
+        .await
+        .unwrap()
 }
 
 pub async fn set_owner(
     instance: &NameRegistry,
     name: &String,
     new_owner: Identity,
-) -> (FuelCallResponse<()>, u64) {
-    get_timestamp_and_call(instance.methods().set_owner(
-        SizedAsciiString::<8>::new(name.to_owned()).unwrap(),
-        new_owner,
-    ))
-    .await
+) -> FuelCallResponse<()> {
+    instance
+        .methods()
+        .set_owner(
+            SizedAsciiString::<8>::new(name.to_owned()).unwrap(),
+            new_owner,
+        )
+        .call()
+        .await
+        .unwrap()
 }

--- a/name-registry/project/registry-contract/tests/utils/mod.rs
+++ b/name-registry/project/registry-contract/tests/utils/mod.rs
@@ -23,6 +23,7 @@ pub async fn setup() -> (NameRegistry, Account, WalletUnlocked) {
         None,
     )
     .await;
+
     let wallet = wallets.pop().unwrap();
     let wallet2 = wallets.pop().unwrap();
 

--- a/oracle/Forc.toml
+++ b/oracle/Forc.toml
@@ -1,1 +1,2 @@
+[workspace]
 members = ["./project/oracle-contract"]

--- a/oracle/project/oracle-contract/Cargo.toml
+++ b/oracle/project/oracle-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["full"] }
 utils = { path = "../utils" }
 

--- a/oracle/project/oracle-contract/Cargo.toml
+++ b/oracle/project/oracle-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 tokio = { version = "1.12", features = ["full"] }
 utils = { path = "../utils" }
 

--- a/oracle/project/oracle-contract/tests/functions/set_price.rs
+++ b/oracle/project/oracle-contract/tests/functions/set_price.rs
@@ -20,7 +20,7 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "Revert(18446744073709486080)")]
+    #[should_panic(expected = "NotOwner")]
     async fn when_not_owner() {
         let (user, wallets) = setup().await;
         user.oracle

--- a/oracle/project/oracle-node/Cargo.toml
+++ b/oracle/project/oracle-node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 anyhow = "1.0.66"
 async-trait = "0.1.58"
 dotenv = "0.15.0"
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 futures = "0.3"
 itertools = "0.10.5"
 reqwest = { version = "0.11.12", features = ["json"] }

--- a/oracle/project/oracle-node/Cargo.toml
+++ b/oracle/project/oracle-node/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 anyhow = "1.0.66"
 async-trait = "0.1.58"
 dotenv = "0.15.0"
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 futures = "0.3"
 itertools = "0.10.5"
 reqwest = { version = "0.11.12", features = ["json"] }

--- a/oracle/project/utils/Cargo.toml
+++ b/oracle/project/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
 
 [lib]
 test = false

--- a/oracle/project/utils/Cargo.toml
+++ b/oracle/project/utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.31.1", features = ["fuel-core-lib"] }
+fuels = { version = "0.32.1", features = ["fuel-core-lib"] }
 
 [lib]
 test = false

--- a/oracle/project/utils/src/lib.rs
+++ b/oracle/project/utils/src/lib.rs
@@ -1,4 +1,4 @@
-use fuels::{contract::contract::CallResponse, prelude::*, signers::wallet::Wallet};
+use fuels::{contract::call_response::FuelCallResponse, prelude::*, signers::wallet::Wallet};
 
 abigen!(
     Oracle,
@@ -26,7 +26,7 @@ pub mod abi_calls {
         contract.methods().price().call().await.unwrap().value
     }
 
-    pub async fn set_price(contract: &Oracle, new_price: u64) -> CallResponse<()> {
+    pub async fn set_price(contract: &Oracle, new_price: u64) -> FuelCallResponse<()> {
         contract
             .methods()
             .set_price(new_price)


### PR DESCRIPTION
## Type of change

- Bug fix
- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- CI
  - Removed `mold` linker since it was causing failures at times
    - Comparing total times across applications in this PR and other PRs it seems like this has overall improved compilation time for some reason. Usually `mold` is just faster overall
  - Changed CI versions to
    - `forc`: `0.31.1` -> `0.32.2`
    - `core`: `0.14.1` -> `0.15.1`
    - `rust`: `1.64` -> `1.66`
- Bumped all apps to `SDK 0.33.0` except `OTC` because of an unknown issue / bug
  - Most changes include changing the panic expected message
  - Some tests have been reordered in the file
- `DAO`: Couple tests were failing for incorrect reasons, changes setup arguments slightly
- `Fundraiser` and perhaps `Escrow` needed a few updates to the deadline / block height because of previous client changes
- `English Auction`: 
  - Has tests that use a bad expected revert message: #330 
- `Name-Registry`: 
  - cleaned up `abi` module but noticed there are multiple missing tests #326 
  - ignored 2 tests because of seemingly breaking changes from the SDK
- Updated README versions and badge

## Related Issues

Closes #324
