### PR TITLE
Remove `mold` from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,15 +56,6 @@ jobs:
       - name: Init cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Install a modern linker (mold)
-        uses: rui314/setup-mold@v1
-
-      - name: Force Rust to use mold globally for compilation
-        run: |
-          touch ~/.cargo/config.toml
-          echo "[target.x86_64-unknown-linux-gnu]" > ~/.cargo/config.toml
-          echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> ~/.cargo/config.toml
       - name: Install rustfmt
         run: rustup component add rustfmt
 
@@ -111,15 +102,6 @@ jobs:
       - name: Init cache
         uses: Swatinem/rust-cache@v1
 
-      - name: Install a modern linker (mold)
-        uses: rui314/setup-mold@v1
-
-      - name: Force Rust to use mold globally for compilation
-        run: |
-          touch ~/.cargo/config.toml
-          echo "[target.x86_64-unknown-linux-gnu]" > ~/.cargo/config.toml
-          echo 'linker = "clang"' >> ~/.cargo/config.toml
-          echo 'rustflags = ["-C", "link-arg=-fuse-ld=/usr/local/bin/mold"]' >> ~/.cargo/config.toml
       - name: Install rustfmt
         run: rustup component add rustfmt
 
@@ -134,3 +116,4 @@ jobs:
 
       - name: Build Sway
         run: forc build --path ${{ matrix.project }}
+


### PR DESCRIPTION
## Type of change

- Bug fix

## Changes

The following changes have been made:

- Removed anything to do with the `mold` linker in both regular (app) and book CI

## Notes

- `mold` has been one part of recent unexpected failures therefore another PR #325 has included it. Trying to hotfix in this one to unblock others because that PR is significantly larger
