### PR TITLE
AMM: Swap and add liquidity scripts (#312)

### DIFF
--- a/AMM/.gitignore
+++ b/AMM/.gitignore
@@ -2,3 +2,6 @@ target
 project/contracts/AMM-contract/out
 project/contracts/exchange-contract/out
 project/contracts/exchange-contract/tests/artifacts/malicious-implementation/out
+project/scripts/atomic-add-liquidity/out
+project/scripts/swap-exact-input/out
+project/scripts/swap-exact-output/out

--- a/AMM/Cargo.toml
+++ b/AMM/Cargo.toml
@@ -3,4 +3,7 @@ resolver = "2"
 members = [
     "./project/contracts/AMM-contract",
     "./project/contracts/exchange-contract",
+    "./project/scripts/atomic-add-liquidity",
+    "./project/scripts/swap-exact-input",
+    "./project/scripts/swap-exact-output",
 ]

--- a/AMM/Forc.toml
+++ b/AMM/Forc.toml
@@ -3,4 +3,7 @@ members = [
   "./project/contracts/AMM-contract",
   "./project/contracts/exchange-contract",
   "./project/contracts/exchange-contract/tests/artifacts/malicious-implementation",
+  "./project/scripts/atomic-add-liquidity",
+  "./project/scripts/swap-exact-input",
+  "./project/scripts/swap-exact-output",
 ]

--- a/AMM/README.md
+++ b/AMM/README.md
@@ -29,17 +29,27 @@ The contracts are designed to
 ```
 AMM/
 ├── project/
-|   └── contracts/
+|   ├── contracts/
 |   |   ├── AMM-contract/
-|   |   |   ├── src/main.sw
-|   |   |   └── tests/harness.rs
 |   |   └── exchange-contract/
-|   |       ├── src/main.sw
-|   |       └── tests/harness.rs
-|   └── libraries/
-|       └── src/interface.sw
+|   ├── scripts/
+|   |   ├── atomic-add-liquidity/
+|   |   ├── swap-exact-input/
+|   |   └── swap-exact-output/
+|   ├── libraries/
+|   |   └── src/interface.sw
+|   └── test-utils/
+|       └── src/lib.rs
 ├── README.md
 └── SPECIFICATION.md
+```
+
+All contracts and scripts have the structure:
+
+```
+contract or script/
+├── src/main.sw
+└── tests/harness.rs
 ```
 
 ## Running the project

--- a/AMM/SPECIFICATION.md
+++ b/AMM/SPECIFICATION.md
@@ -1,36 +1,39 @@
 Table of Contents
 - [Overview](#overview)
 - [Use Cases](#use-cases)
-    - [Actions that users are able to perform](#actions-that-users-are-able-to-perform)
-        - [AMM Contract](#amm)
-            - [Core Functionality](#core-functionality)
-                - [`initialize()`](#initialize)
-                - [`add_pool()`](#add_pool)
-            - [State Checks](#state-checks)
-                - [`pool()`](#pool)
-        - [Exchange Contract](#exchange)
-            - [Core Functionality](#core-functionality-1)
-                - [`constructor()`](#constructor)
-                - [`deposit()`](#deposit)
-                - [`add_liquidity()`](#add_liquidity)
-                - [`remove_liquidity()`](#remove_liquidity)
-                - [`withdraw()`](#withdraw)
-                - [`swap_exact_input()`](#swap_exact_input)
-                - [`swap_exact_output()`](#swap_exact_output)
-            - [Previews](#previews)
-                - [`preview_add_liquidity()`](#preview_add_liquidity)
-                - [`preview_swap_exact_input()`](#preview_swap_exact_input)
-                - [`preview_swap_exact_output()`](#preview_swap_exact_output)
-            - [State Checks](#state-checks-1)
-                - [`balance()`](#balance)
-                - [`pool_info()`](#pool_info)
+    - [AMM Contract](#amm-contract)
+        - [Core Functionality](#core-functionality)
+            - [`initialize()`](#initialize)
+            - [`add_pool()`](#add_pool)
+        - [State Checks](#state-checks)
+            - [`pool()`](#pool)
+    - [Exchange Contract](#exchange-contract)
+        - [Core Functionality](#core-functionality-1)
+            - [`constructor()`](#constructor)
+            - [`deposit()`](#deposit)
+            - [`add_liquidity()`](#add_liquidity)
+            - [`remove_liquidity()`](#remove_liquidity)
+            - [`withdraw()`](#withdraw)
+            - [`swap_exact_input()`](#swap_exact_input)
+            - [`swap_exact_output()`](#swap_exact_output)
+        - [Previews](#previews)
+             - [`preview_add_liquidity()`](#preview_add_liquidity)
+            - [`preview_swap_exact_input()`](#preview_swap_exact_input)
+            - [`preview_swap_exact_output()`](#preview_swap_exact_output)
+        - [State Checks](#state-checks-1)
+            - [`balance()`](#balance)
+            - [`pool_info()`](#pool_info)
+    - [Scripts](#scripts)
+        - [Atomic Add Liquidity](#atomic-add-liquidity)
+        - [Swap Exact Input](#swap-exact-input)
+        - [Swap Exact Output](#swap-exact-output)
 - [Sequence Diagram](#sequence-diagram)
 
 # Overview
 
 This document provides an overview of the application.
 
-It outlines the use cases, i.e., desirable functionality, in addition to requirements for the smart contracts.
+It outlines the use cases, i.e., desirable functionality, in addition to requirements for the smart contracts and scripts.
 
 # Use Cases
 
@@ -38,20 +41,16 @@ This section contains general information about the functionality of the applica
 
 If you are interested in a functional overview then this is the section for you.
 
-## Actions that users are able to perform
+## AMM Contract
 
-This sub-section details what a user is able to do, e.g., click a button and "x, y, z" happens.
+### Core Functionality 
 
-### AMM Contract
-
-#### Core Functionality 
-
-##### `initialize()`
+#### `initialize()`
 
 1. Specifies the legitimate exchange contract implementation that the AMM will operate with (this is a safety mechanism against adding malicious exchange contract implementations to the AMM)
     1. Requires bytecode root of the desired exchange contract implementation
 
-##### `add_pool()`
+#### `add_pool()`
 1. Adds the liquidity pool for the specified asset pair
     1. If the AMM is initialized
     2. Requires the identifiers of the two assets
@@ -59,30 +58,30 @@ This sub-section details what a user is able to do, e.g., click a button and "x,
         1. If the exchange contract is legitimate, i.e., the bytecode root matches
         2. If the exchange contract defines the pool for the specified asset pair
 
-#### State Checks
+### State Checks
 
-##### `pool()`
+#### `pool()`
 
 1. Returns the exchange contract identifier for an asset pair
     1. Requires the identifiers of the two assets
 
-### Exchange Contract
+## Exchange Contract
 
-#### Core Functionality 
+### Core Functionality 
 
-##### `constructor()`
+#### `constructor()`
 
 1. Allows specifying the asset pair that the liquidity pool in the exchange contract will consist of
     1. If the asset pair for the exchange contract has not already been set 
     2. Requires two different asset identifiers
 
-##### `deposit()`
+#### `deposit()`
 
 1. Deposits an asset into the contract
     1. If the asset pair of the pool is set 
     2. Requires any amount of either asset in the pair
 
-##### `add_liquidity()`
+#### `add_liquidity()`
 
 1. Allows adding liquidity to the pool by using up at least one asset's deposited amount
     1. If the asset pair of the pool is set
@@ -93,7 +92,7 @@ This sub-section details what a user is able to do, e.g., click a button and "x,
     5. Requires the desired liquidity amount
     6. Requires a deadline (block height limit)
 
-##### `remove_liquidity()`
+#### `remove_liquidity()`
 
 1. Allows removing liquidity from the pool
     1. If the asset pair of the pool is set
@@ -102,14 +101,14 @@ This sub-section details what a user is able to do, e.g., click a button and "x,
     4. Requires the minimum amounts of both assets to receive after burning
     5. Requires a deadline (block height limit)
 
-##### `withdraw()`
+#### `withdraw()`
 
 1. Allows withdrawing previously deposited assets without using them to add liquidity 
     1. If the asset pair of the pool is set
     2. If the deposited amount of the asset is sufficient
     3. Requires an amount of either asset to withdraw
 
-##### `swap_exact_input()`
+#### `swap_exact_input()`
 
 1. Allows selling an exact amount of an asset for the other asset 
     1. If the asset pair of the pool is set
@@ -122,7 +121,7 @@ This sub-section details what a user is able to do, e.g., click a button and "x,
     7. Requires a deadline (block height limit)
 
 
-##### `swap_exact_output()`
+#### `swap_exact_output()`
 
 1. Allows selling an asset for an exact amount of the other asset 
     1. If the asset pair of the pool is set
@@ -135,41 +134,65 @@ This sub-section details what a user is able to do, e.g., click a button and "x,
         > **NOTE** This is a safety mechanism against excessive slippage. The [`preview_swap_exact_output()`](#preview_swap_exact_output) function can be used to calculate a reasonable maximum input amount.    
     8. Requires a deadline (block height limit)
 
-#### Previews
+### Previews
 
-##### `preview_add_liquidity()`
+#### `preview_add_liquidity()`
 
 1. Returns the amount of the other asset to input and the liquidity asset amount to receive after an add liquidity operation
     1. If the asset pair of the pool is set 
     2. Requires the amount of an asset to input to [`add_liquidity`](#add_liquidity) 
         > **NOTE** If any liquidity in the contract already exists, than the amount of the other asset is calculated based on the ratio of the assets. Otherwise, the ratio is assumed to be 1.   
 
-##### `preview_swap_exact_input()`
+#### `preview_swap_exact_input()`
 
 1. Returns the minimum output amount to receive after a [`swap_exact_input`](#swap_exact_input) and whether the output asset reserves are sufficient for the swap
     1. If the asset pair of the pool is set 
     2. Requires an exact amount of either asset to sell
 
-##### `preview_swap_exact_output()`
+#### `preview_swap_exact_output()`
 
 1. Returns the maximum input amount for a [`swap_exact_output`](#swap_exact_output) and whether the input asset reserves are sufficient for the swap
     1. If the asset pair of the pool is set
     2. If the output asset reserves are sufficient for the swap
     3. Requires an exact amount of either asset to buy
 
-#### State Checks
+### State Checks
 
-##### `balance()`
+#### `balance()`
 
 1. Returns the asset balance of the sender in the contract 
     1. If the asset pair of the pool is set
     2. Requires the asset identifier to return the balance for
 
-##### `pool_info()`
+#### `pool_info()`
 
 1. Returns the pool info, i.e., the identifiers and amounts of assets and the liquidity pool asset amount 
     1. If the asset pair of the pool is set
 
-## Sequence Diagram
+## Scripts
+
+### `atomic-add-liquidity`
+
+1. Deposits pool assets and adds liquidity
+    1. If desired liquidity is more than 0
+    2. If [`deposit`](#deposit) and [`add_liquidity`](#add_liquidity) conditions are met
+
+### `swap-exact-input`
+
+1. Swaps assets along a route by specifying exact input for each swap
+    1. If the route has at least 2 assets
+    2. If the AMM has a pool for each subsequent asset pair in route
+    3. If the bought amount of the last asset is more than the optional minimum output amount 
+    4. If [`swap_exact_input`](#swap_exact_input) conditions are met
+
+### `swap-exact-output`
+
+1. Swaps assets along a route by specifying exact output for each swap
+    1. If the route has at least 2 assets
+    3. If the AMM has a pool for each subsequent asset pair in route
+    3. If the sold amount of the first asset is less than the specified maximum input amount 
+    4. If [`swap_exact_output`](#swap_exact_output) conditions are met
+
+# Sequence Diagram
 
 ![AMM Sequence Diagram](.docs/amm-sequence-diagram.png)

--- a/AMM/project/contracts/AMM-contract/Cargo.toml
+++ b/AMM/project/contracts/AMM-contract/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+test-utils = { path = "../../test-utils" }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 
 [[test]]

--- a/AMM/project/contracts/AMM-contract/src/main.sw
+++ b/AMM/project/contracts/AMM-contract/src/main.sw
@@ -32,7 +32,8 @@ impl AMM for Contract {
 
         let exchange_contract = abi(Exchange, pool.into());
         let pool_info = exchange_contract.pool_info();
-        let pair_matches_exchange_pair = (pool_info.asset_a == asset_pair.0 && pool_info.asset_b == asset_pair.1) || (pool_info.asset_a == asset_pair.1 && pool_info.asset_b == asset_pair.0);
+        let pair = pool_info.reserves;
+        let pair_matches_exchange_pair = (pair.a.id == asset_pair.0 && pair.b.id == asset_pair.1) || (pair.a.id == asset_pair.1 && pair.b.id == asset_pair.0);
 
         require(pair_matches_exchange_pair, InitError::PairDoesNotDefinePool);
 

--- a/AMM/project/contracts/AMM-contract/tests/functions/add_pool.rs
+++ b/AMM/project/contracts/AMM-contract/tests/functions/add_pool.rs
@@ -1,61 +1,72 @@
-use crate::utils::{
-    amm_abi_calls::{add_pool, pool},
-    test_helpers::{deploy_and_construct_exchange_contract, setup, setup_and_initialize},
+use crate::utils::setup;
+use test_utils::{
+    data_structures::ExchangeContractConfiguration, interface::amm::add_pool,
+    setup::common::deploy_and_construct_exchange,
 };
 
 mod success {
     use super::*;
+    use test_utils::interface::amm::pool;
 
     #[tokio::test]
     async fn adds_when_asset_pair_is_in_same_order() {
-        let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
+        let (wallet, amm_instance, asset_pairs) = setup(true).await;
         let pair = asset_pairs[0];
 
-        let exchange = deploy_and_construct_exchange_contract(&wallet, pair, None, None).await;
+        let exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair), None, None, None),
+        )
+        .await;
 
         // adding pair to the AMM contract in the same order as the constructed exchange contract
-        add_pool(&amm_instance, pair, exchange.contract_id).await;
+        add_pool(&amm_instance, pair, exchange.id).await;
 
         let exchange_contract_id_in_storage = pool(&amm_instance, pair).await;
 
         assert_ne!(exchange_contract_id_in_storage, None);
-        assert_eq!(
-            exchange_contract_id_in_storage.unwrap(),
-            exchange.contract_id
-        );
+        assert_eq!(exchange_contract_id_in_storage.unwrap(), exchange.id);
     }
 
     #[tokio::test]
     async fn adds_when_asset_pair_is_in_reverse_order() {
-        let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
+        let (wallet, amm_instance, asset_pairs) = setup(true).await;
         let pair = asset_pairs[0];
 
-        let exchange = deploy_and_construct_exchange_contract(&wallet, pair, None, None).await;
+        let exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair), None, None, None),
+        )
+        .await;
 
         // adding pair to the AMM contract in the reverse order as the constructed exchange contract
-        add_pool(&amm_instance, (pair.1, pair.0), exchange.contract_id).await;
+        add_pool(&amm_instance, (pair.1, pair.0), exchange.id).await;
 
         let exchange_contract_id_in_storage = pool(&amm_instance, pair).await;
 
         assert_ne!(exchange_contract_id_in_storage, None);
-        assert_eq!(
-            exchange_contract_id_in_storage.unwrap(),
-            exchange.contract_id
-        );
+        assert_eq!(exchange_contract_id_in_storage.unwrap(), exchange.id);
     }
 
     #[tokio::test]
     async fn adds_more_than_once() {
-        let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
+        let (wallet, amm_instance, asset_pairs) = setup(true).await;
         let pair_1 = asset_pairs[0];
         let pair_2 = asset_pairs[1];
 
-        let exchange_1 = deploy_and_construct_exchange_contract(&wallet, pair_1, None, None).await;
-        let exchange_2 =
-            deploy_and_construct_exchange_contract(&wallet, pair_2, None, Some(1)).await;
+        let exchange_1 = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair_1), None, None, None),
+        )
+        .await;
+        let exchange_2 = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair_2), None, None, Some([1u8; 32])),
+        )
+        .await;
 
-        add_pool(&amm_instance, pair_1, exchange_1.contract_id).await;
-        add_pool(&amm_instance, pair_2, exchange_2.contract_id).await;
+        add_pool(&amm_instance, pair_1, exchange_1.id).await;
+        add_pool(&amm_instance, pair_2, exchange_2.id).await;
 
         let exchange_contract_id_in_storage_of_pair_1 = pool(&amm_instance, pair_1).await;
         let exchange_contract_id_in_storage_of_pair_2 = pool(&amm_instance, pair_2).await;
@@ -63,12 +74,12 @@ mod success {
         assert_ne!(exchange_contract_id_in_storage_of_pair_1, None);
         assert_eq!(
             exchange_contract_id_in_storage_of_pair_1.unwrap(),
-            exchange_1.contract_id
+            exchange_1.id
         );
         assert_ne!(exchange_contract_id_in_storage_of_pair_2, None);
         assert_eq!(
             exchange_contract_id_in_storage_of_pair_2.unwrap(),
-            exchange_2.contract_id
+            exchange_2.id
         );
     }
 }
@@ -78,38 +89,52 @@ mod revert {
 
     #[tokio::test]
     #[should_panic(expected = "BytecodeRootNotSet")]
-    async fn when_not_initialized() {
-        let (wallet, amm_instance, asset_pairs) = setup().await;
+    async fn when_uninitialized() {
+        let (wallet, amm_instance, asset_pairs) = setup(false).await;
         let pair = asset_pairs[0];
 
-        let exchange = deploy_and_construct_exchange_contract(&wallet, pair, None, None).await;
+        let exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair), None, None, None),
+        )
+        .await;
 
-        add_pool(&amm_instance, pair, exchange.contract_id).await;
+        add_pool(&amm_instance, pair, exchange.id).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "BytecodeRootDoesNotMatch")]
-    async fn when_exchange_contract_byteroot_invalid() {
-        let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
+    async fn when_byteroot_does_not_match() {
+        let (wallet, amm_instance, asset_pairs) = setup(true).await;
         let pair = asset_pairs[0];
 
-        let invalid_exchange =
-            deploy_and_construct_exchange_contract(&wallet, pair, Some(true), None).await;
+        let invalid_exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair), None, Some(true), None),
+        )
+        .await;
 
-        add_pool(&amm_instance, pair, invalid_exchange.contract_id).await;
+        add_pool(&amm_instance, pair, invalid_exchange.id).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "PairDoesNotDefinePool")]
     async fn when_exchange_contract_does_not_match_pair() {
-        let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
+        let (wallet, amm_instance, asset_pairs) = setup(true).await;
         let pair = asset_pairs[0];
         let another_pair = asset_pairs[1];
 
-        let _exchange = deploy_and_construct_exchange_contract(&wallet, pair, None, None).await;
-        let another_exchange =
-            deploy_and_construct_exchange_contract(&wallet, another_pair, None, Some(1)).await;
+        let _exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair), None, None, None),
+        )
+        .await;
+        let another_exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(another_pair), None, None, Some([1u8; 32])),
+        )
+        .await;
 
-        add_pool(&amm_instance, pair, another_exchange.contract_id).await;
+        add_pool(&amm_instance, pair, another_exchange.id).await;
     }
 }

--- a/AMM/project/contracts/AMM-contract/tests/functions/initialize.rs
+++ b/AMM/project/contracts/AMM-contract/tests/functions/initialize.rs
@@ -1,34 +1,38 @@
-use crate::utils::{
-    amm_abi_calls::initialize,
-    test_helpers::{
-        bytecode_root, deploy_and_construct_exchange_contract, setup, setup_and_initialize,
-    },
-};
+use crate::utils::setup;
+use test_utils::interface::amm::initialize;
 
 mod success {
     use super::*;
+    use test_utils::setup::common::exchange_bytecode_root;
 
     #[tokio::test]
     async fn initializes() {
-        let (_wallet, amm_instance, _asset_pairs) = setup().await;
+        let (_wallet, amm_instance, _asset_pairs) = setup(false).await;
 
-        let calculated_bytecode_root = bytecode_root().await;
+        let calculated_bytecode_root = exchange_bytecode_root().await;
         initialize(&amm_instance, calculated_bytecode_root).await;
     }
 }
 
 mod revert {
     use super::*;
+    use test_utils::{
+        data_structures::ExchangeContractConfiguration,
+        setup::common::deploy_and_construct_exchange,
+    };
 
     #[tokio::test]
     #[should_panic(expected = "BytecodeRootAlreadySet")]
     async fn when_already_initialized() {
-        let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
+        let (wallet, amm_instance, asset_pairs) = setup(true).await;
 
-        let exchange =
-            deploy_and_construct_exchange_contract(&wallet, asset_pairs[0], None, None).await;
+        let exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(asset_pairs[0]), Some(true), None, None),
+        )
+        .await;
 
         // already initialized
-        initialize(&amm_instance, exchange.bytecode_root).await;
+        initialize(&amm_instance, exchange.bytecode_root.unwrap()).await;
     }
 }

--- a/AMM/project/contracts/AMM-contract/tests/functions/pool.rs
+++ b/AMM/project/contracts/AMM-contract/tests/functions/pool.rs
@@ -1,47 +1,49 @@
-use crate::utils::{
-    amm_abi_calls::{add_pool, pool},
-    test_helpers::{deploy_and_construct_exchange_contract, setup_and_initialize},
-};
-
 mod success {
-    use super::*;
+    use crate::utils::setup;
+    use test_utils::{
+        data_structures::ExchangeContractConfiguration,
+        interface::amm::{add_pool, pool},
+        setup::common::deploy_and_construct_exchange,
+    };
 
     #[tokio::test]
     async fn gets_some() {
-        let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
+        let (wallet, amm_instance, asset_pairs) = setup(true).await;
         let pair = asset_pairs[0];
 
-        let exchange = deploy_and_construct_exchange_contract(&wallet, pair, None, None).await;
+        let exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair), None, None, None),
+        )
+        .await;
 
-        add_pool(&amm_instance, pair, exchange.contract_id).await;
+        add_pool(&amm_instance, pair, exchange.id).await;
 
         let exchange_contract_id_in_storage = pool(&amm_instance, pair).await;
 
         assert_ne!(exchange_contract_id_in_storage, None);
-        assert_eq!(
-            exchange_contract_id_in_storage.unwrap(),
-            exchange.contract_id
-        );
+        assert_eq!(exchange_contract_id_in_storage.unwrap(), exchange.id);
     }
 
     #[tokio::test]
     async fn gets_none() {
-        let (wallet, amm_instance, asset_pairs) = setup_and_initialize().await;
+        let (wallet, amm_instance, asset_pairs) = setup(true).await;
         let pair = asset_pairs[0];
         let another_pair = asset_pairs[1];
 
-        let exchange = deploy_and_construct_exchange_contract(&wallet, pair, None, None).await;
+        let exchange = deploy_and_construct_exchange(
+            &wallet,
+            &ExchangeContractConfiguration::new(Some(pair), None, None, None),
+        )
+        .await;
 
-        add_pool(&amm_instance, pair, exchange.contract_id).await;
+        add_pool(&amm_instance, pair, exchange.id).await;
 
         let exchange_contract_id_in_storage = pool(&amm_instance, pair).await;
         let non_existent_exchange_contract_id_in_storage = pool(&amm_instance, another_pair).await;
 
         assert_ne!(exchange_contract_id_in_storage, None);
-        assert_eq!(
-            exchange_contract_id_in_storage.unwrap(),
-            exchange.contract_id
-        );
+        assert_eq!(exchange_contract_id_in_storage.unwrap(), exchange.id);
         assert_eq!(non_existent_exchange_contract_id_in_storage, None);
     }
 }

--- a/AMM/project/contracts/AMM-contract/tests/utils/mod.rs
+++ b/AMM/project/contracts/AMM-contract/tests/utils/mod.rs
@@ -1,189 +1,22 @@
-use fuels::{contract::call_response::FuelCallResponse, prelude::*, tx::Contract as TxContract};
+use fuels::prelude::*;
+use test_utils::{
+    data_structures::WalletAssetConfiguration,
+    interface::AMM,
+    setup::common::{deploy_amm, deploy_and_initialize_amm, setup_wallet_and_provider},
+};
 
-abigen!(
-    AMM,
-    "./project/contracts/AMM-contract/out/debug/AMM-contract-abi.json"
-);
-abigen!(
-    Exchange,
-    "./project/contracts/exchange-contract/out/debug/exchange-contract-abi.json"
-);
+pub async fn setup(initialize: bool) -> (WalletUnlocked, AMM, Vec<(AssetId, AssetId)>) {
+    let (wallet, asset_ids, _provider) =
+        setup_wallet_and_provider(&WalletAssetConfiguration::default()).await;
 
-pub struct ExchangeContract {
-    pub contract_id: ContractId,
-    pub bytecode_root: ContractId,
-}
-
-pub mod paths {
-    pub const AMM_CONTRACT_BINARY_PATH: &str = "./out/debug/AMM-contract.bin";
-    pub const AMM_CONTRACT_STORAGE_PATH: &str = "./out/debug/AMM-contract-storage_slots.json";
-    pub const EXCHANGE_CONTRACT_BINARY_PATH: &str =
-        "../exchange-contract/out/debug/exchange-contract.bin";
-    pub const MALICIOUS_EXCHANGE_CONTRACT_BINARY_PATH: &str =
-        "../exchange-contract/tests/artifacts/malicious-implementation/out/debug/malicious-implementation.bin";
-}
-
-pub mod exchange_abi_calls {
-    use super::*;
-
-    pub async fn constructor(
-        contract: &Exchange,
-        pair: (ContractId, ContractId),
-    ) -> FuelCallResponse<()> {
-        let receipt = contract.methods().constructor(pair).call().await;
-        receipt.unwrap()
-    }
-}
-
-pub mod amm_abi_calls {
-    use super::*;
-
-    pub async fn initialize(
-        contract: &AMM,
-        exchange_bytecode_root: ContractId,
-    ) -> FuelCallResponse<()> {
-        contract
-            .methods()
-            .initialize(exchange_bytecode_root)
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn add_pool(
-        contract: &AMM,
-        asset_pair: (ContractId, ContractId),
-        pool: ContractId,
-    ) -> FuelCallResponse<()> {
-        contract
-            .methods()
-            .add_pool(asset_pair, pool)
-            .set_contracts(&[pool.into()])
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn pool(contract: &AMM, asset_pair: (ContractId, ContractId)) -> Option<ContractId> {
-        contract
-            .methods()
-            .pool(asset_pair)
-            .call()
-            .await
-            .unwrap()
-            .value
-    }
-}
-
-pub mod test_helpers {
-    use super::*;
-    use amm_abi_calls::initialize;
-    use exchange_abi_calls::constructor;
-    use paths::{
-        AMM_CONTRACT_BINARY_PATH, AMM_CONTRACT_STORAGE_PATH, EXCHANGE_CONTRACT_BINARY_PATH,
-        MALICIOUS_EXCHANGE_CONTRACT_BINARY_PATH,
+    let amm = if initialize {
+        deploy_and_initialize_amm(&wallet).await
+    } else {
+        deploy_amm(&wallet).await
     };
 
-    pub async fn bytecode_root() -> ContractId {
-        // calculate the bytecode root of the exchange contract
-        let exchange_raw_code = Contract::load_contract(
-            EXCHANGE_CONTRACT_BINARY_PATH,
-            &StorageConfiguration::default().storage_path,
-        )
-        .unwrap()
-        .raw;
-        (*TxContract::root_from_code(exchange_raw_code)).into()
-    }
+    // setup two asset pairs that will be used in tests
+    let asset_pairs = vec![(asset_ids[0], asset_ids[1]), (asset_ids[1], asset_ids[2])];
 
-    pub async fn initialize_amm_contract(wallet: &WalletUnlocked, amm_instance: &AMM) {
-        Contract::deploy(
-            EXCHANGE_CONTRACT_BINARY_PATH,
-            &wallet,
-            TxParameters::default(),
-            StorageConfiguration::default(),
-        )
-        .await
-        .unwrap();
-
-        initialize(amm_instance, bytecode_root().await).await;
-    }
-
-    pub async fn deploy_and_construct_exchange_contract(
-        wallet: &WalletUnlocked,
-        asset_pair: (ContractId, ContractId),
-        malicious: Option<bool>,
-        index_for_salt: Option<u8>,
-    ) -> ExchangeContract {
-        let salt = [index_for_salt.unwrap_or(0u8); 32];
-
-        let exchange_contract_id = Contract::deploy_with_parameters(
-            if !malicious.unwrap_or(false) {
-                EXCHANGE_CONTRACT_BINARY_PATH
-            } else {
-                MALICIOUS_EXCHANGE_CONTRACT_BINARY_PATH
-            },
-            &wallet,
-            TxParameters::default(),
-            StorageConfiguration::default(),
-            Salt::from(salt),
-        )
-        .await
-        .unwrap();
-
-        let exchange_instance = Exchange::new(exchange_contract_id.clone(), wallet.clone());
-        constructor(&exchange_instance, asset_pair).await;
-        ExchangeContract {
-            contract_id: ContractId::new(*exchange_contract_id.hash()),
-            bytecode_root: bytecode_root().await,
-        }
-    }
-
-    pub async fn setup_and_initialize() -> (WalletUnlocked, AMM, Vec<(ContractId, ContractId)>) {
-        let (wallet, amm_instance, asset_pairs) = setup().await;
-
-        initialize_amm_contract(&wallet, &amm_instance).await;
-
-        (wallet, amm_instance, asset_pairs)
-    }
-
-    pub async fn setup() -> (WalletUnlocked, AMM, Vec<(ContractId, ContractId)>) {
-        // setup wallet and provider
-        let mut wallet = WalletUnlocked::new_random(None);
-        let num_assets = 3;
-        let coins_per_asset = 1;
-        let amount_per_coin = 1_000_000;
-        let (coins, asset_ids) = setup_multiple_assets_coins(
-            wallet.address(),
-            num_assets,
-            coins_per_asset,
-            amount_per_coin,
-        );
-        let (provider, _socket_addr) = setup_test_provider(coins.clone(), vec![], None, None).await;
-        wallet.set_provider(provider);
-
-        // setup AMM contract
-        let amm_contract_id = Contract::deploy(
-            AMM_CONTRACT_BINARY_PATH,
-            &wallet,
-            TxParameters::default(),
-            StorageConfiguration::with_storage_path(Some(AMM_CONTRACT_STORAGE_PATH.to_string())),
-        )
-        .await
-        .unwrap();
-        let amm_instance = AMM::new(amm_contract_id.clone(), wallet.clone());
-
-        // setup two asset pairs that will be used in tests
-        let asset_pairs = vec![
-            (
-                ContractId::new(*asset_ids[0]),
-                ContractId::new(*asset_ids[1]),
-            ),
-            (
-                ContractId::new(*asset_ids[1]),
-                ContractId::new(*asset_ids[2]),
-            ),
-        ];
-
-        (wallet, amm_instance, asset_pairs)
-    }
+    (wallet, amm.instance, asset_pairs)
 }

--- a/AMM/project/contracts/exchange-contract/Cargo.toml
+++ b/AMM/project/contracts/exchange-contract/Cargo.toml
@@ -6,7 +6,8 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.33.0", features = ["fuel-core-lib"] }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+test-utils = { path = "../../test-utils" }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 
 [[test]]

--- a/AMM/project/contracts/exchange-contract/src/errors.sw
+++ b/AMM/project/contracts/exchange-contract/src/errors.sw
@@ -1,23 +1,24 @@
 library errors;
 
 pub enum InitError {
-    CannotReinitialize: (),
-    NotInitialized: (),
-    PoolAssetsCannotBeIdentical: (),
+    AssetPairAlreadySet: (),
+    AssetPairNotSet: (),
+    IdenticalAssets: (),
 }
 
 pub enum InputError {
-    AmountCannotBeZero: (),
-    AmountMustBeZero: (),
-    AmountTooLow: u64,
-    DeadlinePassed: (),
+    CannotAddLessThanMinimumLiquidity: u64,
+    DeadlinePassed: u64,
+    ExpectedNonZeroAmount: ContractId,
+    ExpectedNonZeroParameter: ContractId,
+    ExpectedZeroAmount: (),
     InvalidAsset: (),
 }
 
 pub enum TransactionError {
-    DepositCannotBeZero: (),
     DesiredAmountTooHigh: u64,
-    InsufficientLiquidity: (),
-    LiquidityCannotBeZero: (),
-    ProvidedAmountTooLow: u64,
+    DesiredAmountTooLow: u64,
+    ExpectedNonZeroDeposit: ContractId,
+    InsufficientReserve: ContractId,
+    NoLiquidityToRemove: (),
 }

--- a/AMM/project/contracts/exchange-contract/src/events.sw
+++ b/AMM/project/contracts/exchange-contract/src/events.sw
@@ -1,53 +1,45 @@
 library events;
 
+use libraries::data_structures::{Asset, AssetPair};
+
 pub struct AddLiquidityEvent {
-    /// Amount of asset A added to reserves
-    asset_a: u64,
-    /// Amount of asset B added to reserves
-    asset_b: u64,
-    /// Amount of liquidity pool assets minted and transferred to sender
-    liquidity: u64,
+    /// Identifiers and amounts of assets added to reserves
+    added_assets: AssetPair,
+    /// Identifier and amount of liquidity pool assets minted and transferred to sender
+    liquidity: Asset,
 }
 
 pub struct DefineAssetPairEvent {
-    /// The pair that makes up the pool
-    pair: (ContractId, ContractId),
+    /// Identifier of one of the assets that make up the pool
+    asset_a_id: ContractId,
+    /// Identifier of the other asset
+    asset_b_id: ContractId,
 }
 
 pub struct DepositEvent {
-    /// Deposited amount of the asset that may be withdrawn of used to add liquidity
-    amount: u64,
-    /// Deposited asset that is either asset A or asset B
-    asset: ContractId,
+    /// Deposited asset that may be withdrawn or used to add liquidity
+    deposited_asset: Asset,
     /// New deposit balance of asset in contract
-    balance: u64,
+    new_balance: u64,
 }
 
 pub struct RemoveLiquidityEvent {
-    /// Amount of asset A removed from reserves and transferred to sender
-    amount_a: u64,
-    /// Amount of asset B removed from reserves and transferred to sender
-    amount_b: u64,
-    /// Amount of liquidity pool assets burned
-    liquidity: u64,
+    /// Identifiers and amounts of assets removed from reserves and transferred to sender
+    removed_reserve: AssetPair,
+    /// Identifier and amount of burned liquidity pool assets
+    burned_liquidity: Asset,
 }
 
 pub struct SwapEvent {
-    /// Amount of the output asset that was bought
-    bought: u64,
-    /// Identifier of input asset
-    input: ContractId,
-    /// Identifier of output asset
-    output: ContractId,
-    /// Amount of the input asset that was sold
-    sold: u64,
+    /// Identifier and amount of sold asset
+    input: Asset,
+    /// Identifier and amount of bought asset
+    output: Asset,
 }
 
 pub struct WithdrawEvent {
-    /// Amount of withdrawal
-    amount: u64,
-    /// Identifier of withdrawn asset
-    asset: ContractId,
+    /// Identifier and amount of withdrawn asset
+    withdrawn_asset: Asset,
     /// Remaining deposit balance of asset in contract
-    balance: u64,
+    remaining_balance: u64,
 }

--- a/AMM/project/contracts/exchange-contract/src/main.sw
+++ b/AMM/project/contracts/exchange-contract/src/main.sw
@@ -15,6 +15,8 @@ use events::{
 };
 use libraries::{
     data_structures::{
+        Asset,
+        AssetPair,
         PoolInfo,
         PreviewAddLiquidityInfo,
         PreviewSwapInfo,
@@ -39,11 +41,10 @@ use std::{
     },
 };
 use utils::{
-    determine_output_asset,
-    div_multiply,
+    determine_assets,
     maximum_input_for_exact_output,
     minimum_output_given_exact_input,
-    multiply_div,
+    multiply_divide,
 };
 
 storage {
@@ -52,45 +53,40 @@ storage {
     /// Total amount of the liquidity pool asset that has a unique identifier different from the identifiers of assets on either side of the pool.
     liquidity_pool_supply: u64 = 0,
     /// The unique identifiers that make up the pool that can be set only once using the `constructor`.
-    pair: Option<(ContractId, ContractId)> = Option::None,
-    /// Reserve amounts per asset A and asset B
-    reserves: StorageMap<ContractId, u64> = StorageMap {},
+    pair: Option<AssetPair> = Option::None,
 }
 
 impl Exchange for Contract {
     #[storage(read, write)]
     fn add_liquidity(desired_liquidity: u64, deadline: u64) -> u64 {
-        require(storage.pair.is_some(), InitError::NotInitialized);
-        require(deadline > height(), InputError::DeadlinePassed);
-        require(msg_amount() == 0, InputError::AmountMustBeZero);
-        require(MINIMUM_LIQUIDITY <= desired_liquidity, InputError::AmountTooLow(desired_liquidity));
+        require(storage.pair.is_some(), InitError::AssetPairNotSet);
+        require(deadline > height(), InputError::DeadlinePassed(deadline));
+        require(msg_amount() == 0, InputError::ExpectedZeroAmount);
+        require(MINIMUM_LIQUIDITY <= desired_liquidity, InputError::CannotAddLessThanMinimumLiquidity(desired_liquidity));
 
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
         let sender = msg_sender().unwrap();
-        let total_liquidity = storage.liquidity_pool_supply;
-        let asset_a_in_deposit = storage.deposits.get((sender, asset_a_id));
-        let asset_b_in_deposit = storage.deposits.get((sender, asset_b_id));
-        let asset_a_in_reserve = storage.reserves.get(asset_a_id);
-        let asset_b_in_reserve = storage.reserves.get(asset_b_id);
-        let mut added_a = 0;
-        let mut added_b = 0;
-        let mut added_liquidity = 0;
+        let reserves = storage.pair.unwrap();
+        let deposits = AssetPair::new(Asset::new(reserves.a.id, storage.deposits.get((sender, reserves.a.id))), Asset::new(reserves.b.id, storage.deposits.get((sender, reserves.b.id))));
 
         // checking this because this will either result in a math error or adding no liquidity at all
-        require(asset_a_in_deposit != 0, TransactionError::DepositCannotBeZero);
-        require(asset_b_in_deposit != 0, TransactionError::DepositCannotBeZero);
+        require(deposits.a.amount != 0, TransactionError::ExpectedNonZeroDeposit(deposits.a.id));
+        require(deposits.b.amount != 0, TransactionError::ExpectedNonZeroDeposit(deposits.b.id));
+
+        let total_liquidity = storage.liquidity_pool_supply;
+
+        let mut added_assets = AssetPair::new(Asset::new(reserves.a.id, 0), Asset::new(reserves.b.id, 0));
+        let mut added_liquidity = 0;
 
         // adding liquidity for the first time
         // use up all the deposited amounts of assets to determine the ratio
-        if asset_a_in_reserve == 0 && asset_b_in_reserve == 0 {
-            added_liquidity = (asset_a_in_deposit * asset_b_in_deposit).sqrt();
+        if reserves.a.amount == 0 && reserves.b.amount == 0 {
+            added_liquidity = (deposits.a.amount * deposits.b.amount).sqrt();
             require(desired_liquidity <= added_liquidity, TransactionError::DesiredAmountTooHigh(desired_liquidity));
-            added_a = asset_a_in_deposit;
-            added_b = asset_b_in_deposit;
+            added_assets.a.amount = deposits.a.amount;
+            added_assets.b.amount = deposits.b.amount;
 
             // add amounts to reserves
-            storage.reserves.insert(asset_a_id, added_a);
-            storage.reserves.insert(asset_b_id, added_b);
+            storage.pair = Option::Some(added_assets);
 
             // mint liquidity pool asset and transfer to sender
             mint(added_liquidity);
@@ -98,25 +94,24 @@ impl Exchange for Contract {
             transfer(added_liquidity, contract_id(), sender);
         } else { // adding further liquidity based on current ratio
             // attempt to add liquidity by using up the deposited asset A amount
-            let b_to_attempt = multiply_div(asset_a_in_deposit, asset_b_in_reserve, asset_a_in_reserve);
+            let b_to_attempt = multiply_divide(deposits.a.amount, reserves.b.amount, reserves.a.amount);
 
             // continue adding based on asset A if deposited asset B amount is sufficient
-            if b_to_attempt <= asset_b_in_deposit {
-                added_liquidity = multiply_div(b_to_attempt, total_liquidity, asset_b_in_reserve);
+            if b_to_attempt <= deposits.b.amount {
+                added_liquidity = multiply_divide(b_to_attempt, total_liquidity, reserves.b.amount);
                 require(desired_liquidity <= added_liquidity, TransactionError::DesiredAmountTooHigh(desired_liquidity));
-                added_a = asset_a_in_deposit;
-                added_b = b_to_attempt;
+                added_assets.a.amount = deposits.a.amount;
+                added_assets.b.amount = b_to_attempt;
             } else { // attempt to add liquidity by using up the deposited asset B amount
-                let a_to_attempt = multiply_div(asset_b_in_deposit, asset_a_in_reserve, asset_b_in_reserve);
-                added_liquidity = multiply_div(a_to_attempt, total_liquidity, asset_a_in_reserve);
+                let a_to_attempt = multiply_divide(deposits.b.amount, reserves.a.amount, reserves.b.amount);
+                added_liquidity = multiply_divide(a_to_attempt, total_liquidity, reserves.a.amount);
                 require(desired_liquidity <= added_liquidity, TransactionError::DesiredAmountTooHigh(desired_liquidity));
-                added_a = a_to_attempt;
-                added_b = asset_b_in_deposit;
+                added_assets.a.amount = a_to_attempt;
+                added_assets.b.amount = deposits.b.amount;
             }
 
             // add new asset amounts to reserves
-            storage.reserves.insert(asset_a_id, asset_a_in_reserve + added_a);
-            storage.reserves.insert(asset_b_id, asset_b_in_reserve + added_b);
+            storage.pair = Option::Some(reserves + added_assets);
 
             // mint liquidity pool asset and transfer to sender
             mint(added_liquidity);
@@ -124,136 +119,128 @@ impl Exchange for Contract {
             transfer(added_liquidity, contract_id(), sender);
 
             // transfer remaining deposit amounts back to the sender
-            let refund_a = asset_a_in_deposit - added_a;
-            let refund_b = asset_b_in_deposit - added_b;
+            let refund = deposits - added_assets;
 
-            if refund_a > 0 {
-                transfer(refund_a, asset_a_id, sender);
+            if refund.a.amount > 0 {
+                transfer(refund.a.amount, refund.a.id, sender);
             }
 
-            if refund_b > 0 {
-                transfer(refund_b, asset_b_id, sender);
+            if refund.b.amount > 0 {
+                transfer(refund.b.amount, refund.b.id, sender);
             }
         }
 
-        storage.deposits.insert((sender, asset_a_id), 0);
-        storage.deposits.insert((sender, asset_b_id), 0);
+        storage.deposits.insert((sender, deposits.a.id), 0);
+        storage.deposits.insert((sender, deposits.b.id), 0);
 
         log(AddLiquidityEvent {
-            asset_a: added_a,
-            asset_b: added_b,
-            liquidity: added_liquidity,
+            added_assets,
+            liquidity: Asset::new(contract_id(), added_liquidity),
         });
 
         added_liquidity
     }
 
     #[storage(read, write)]
-    fn constructor(pair: (ContractId, ContractId)) {
-        require(storage.pair.is_none(), InitError::CannotReinitialize);
-        require(pair.0 != pair.1, InitError::PoolAssetsCannotBeIdentical);
+    fn constructor(asset_a: ContractId, asset_b: ContractId) {
+        require(storage.pair.is_none(), InitError::AssetPairAlreadySet);
+        require(asset_a != asset_b, InitError::IdenticalAssets);
 
-        storage.pair = Option::Some(pair);
-        log(DefineAssetPairEvent { pair });
+        storage.pair = Option::Some(AssetPair::new(Asset::new(asset_a, 0), Asset::new(asset_b, 0)));
+        log(DefineAssetPairEvent {
+            asset_a_id: asset_a,
+            asset_b_id: asset_b,
+        });
     }
 
     #[storage(read, write)]
     fn deposit() {
-        require(storage.pair.is_some(), InitError::NotInitialized);
+        require(storage.pair.is_some(), InitError::AssetPairNotSet);
 
         let deposit_asset = msg_asset_id();
 
-        require(deposit_asset == storage.pair.unwrap().0 || deposit_asset == storage.pair.unwrap().1, InputError::InvalidAsset);
+        require(deposit_asset == storage.pair.unwrap().a.id || deposit_asset == storage.pair.unwrap().b.id, InputError::InvalidAsset);
 
         let sender = msg_sender().unwrap();
         let amount = msg_amount();
-        let new_deposit_amount = storage.deposits.get((sender, deposit_asset)) + amount;
-        storage.deposits.insert((sender, deposit_asset), new_deposit_amount);
+        let new_balance = storage.deposits.get((sender, deposit_asset)) + amount;
+        storage.deposits.insert((sender, deposit_asset), new_balance);
 
         log(DepositEvent {
-            asset: deposit_asset,
-            amount,
-            balance: new_deposit_amount,
+            deposited_asset: Asset::new(deposit_asset, amount),
+            new_balance,
         });
     }
 
     #[storage(read, write)]
     fn remove_liquidity(min_asset_a: u64, min_asset_b: u64, deadline: u64) -> RemoveLiquidityInfo {
-        require(storage.pair.is_some(), InitError::NotInitialized);
+        require(storage.pair.is_some(), InitError::AssetPairNotSet);
 
         let total_liquidity = storage.liquidity_pool_supply;
-        require(total_liquidity > 0, TransactionError::LiquidityCannotBeZero);
+        require(total_liquidity > 0, TransactionError::NoLiquidityToRemove);
 
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
+        let reserves = storage.pair.unwrap();
 
-        require(msg_asset_id() == contract_id(), InputError::InvalidAsset);
-        require(min_asset_a > 0 && min_asset_b > 0, InputError::AmountCannotBeZero);
-        require(deadline > height(), InputError::DeadlinePassed);
+        require(min_asset_a > 0, InputError::ExpectedNonZeroParameter(reserves.a.id));
+        require(min_asset_b > 0, InputError::ExpectedNonZeroParameter(reserves.b.id));
+        require(deadline > height(), InputError::DeadlinePassed(deadline));
 
-        let amount = msg_amount();
+        let burned_liquidity = Asset::new(contract_id(), msg_amount());
 
-        require(amount > 0, InputError::AmountCannotBeZero);
+        require(burned_liquidity.id == msg_asset_id(), InputError::InvalidAsset);
+        require(burned_liquidity.amount > 0, InputError::ExpectedNonZeroAmount(burned_liquidity.id));
+
+        let mut removed_assets = AssetPair::new(Asset::new(reserves.a.id, 0), Asset::new(reserves.b.id, 0));
+        removed_assets.a.amount = multiply_divide(burned_liquidity.amount, reserves.a.amount, total_liquidity);
+        removed_assets.b.amount = multiply_divide(burned_liquidity.amount, reserves.b.amount, total_liquidity);
+
+        require(removed_assets.a.amount >= min_asset_a, TransactionError::DesiredAmountTooHigh(min_asset_a));
+        require(removed_assets.b.amount >= min_asset_b, TransactionError::DesiredAmountTooHigh(min_asset_b));
+
+        burn(burned_liquidity.amount);
+        storage.liquidity_pool_supply = total_liquidity - burned_liquidity.amount;
+        storage.pair = Option::Some(reserves - removed_assets);
 
         let sender = msg_sender().unwrap();
-        let asset_a_in_reserve = storage.reserves.get(asset_a_id);
-        let asset_b_in_reserve = storage.reserves.get(asset_b_id);
-        let asset_a_amount_to_remove = multiply_div(amount, asset_a_in_reserve, total_liquidity);
-        let asset_b_amount_to_remove = multiply_div(amount, asset_b_in_reserve, total_liquidity);
-
-        require(asset_a_amount_to_remove >= min_asset_a, TransactionError::DesiredAmountTooHigh(min_asset_a));
-        require(asset_b_amount_to_remove >= min_asset_b, TransactionError::DesiredAmountTooHigh(min_asset_b));
-
-        burn(amount);
-        storage.liquidity_pool_supply = total_liquidity - amount;
-        storage.reserves.insert(asset_b_id, asset_b_in_reserve - asset_b_amount_to_remove);
-        storage.reserves.insert(asset_a_id, asset_a_in_reserve - asset_a_amount_to_remove);
-        transfer(asset_a_amount_to_remove, asset_a_id, sender);
-        transfer(asset_b_amount_to_remove, asset_b_id, sender);
+        transfer(removed_assets.a.amount, removed_assets.a.id, sender);
+        transfer(removed_assets.b.amount, removed_assets.b.id, sender);
 
         log(RemoveLiquidityEvent {
-            amount_a: asset_a_amount_to_remove,
-            amount_b: asset_b_amount_to_remove,
-            liquidity: amount,
+            removed_reserve: removed_assets,
+            burned_liquidity,
         });
 
         RemoveLiquidityInfo {
-            asset_a_amount: asset_a_amount_to_remove,
-            asset_b_amount: asset_b_amount_to_remove,
-            liquidity: amount,
+            removed_amounts: removed_assets,
+            burned_liquidity,
         }
     }
 
     #[storage(read, write)]
     fn swap_exact_input(min_output: Option<u64>, deadline: u64) -> u64 {
-        let input_asset = msg_asset_id();
-        let output_asset = determine_output_asset(input_asset, storage.pair);
+        require(deadline >= height(), InputError::DeadlinePassed(deadline));
 
-        require(deadline >= height(), InputError::DeadlinePassed);
+        let reserves = storage.pair;
+        let (mut input_asset, mut output_asset) = determine_assets(msg_asset_id(), reserves);
 
         let exact_input = msg_amount();
-        require(exact_input > 0, InputError::AmountCannotBeZero);
+        require(exact_input > 0, InputError::ExpectedNonZeroAmount(input_asset.id));
 
-        let sender = msg_sender().unwrap();
-        let input_asset_in_reserve = storage.reserves.get(input_asset);
-        let output_asset_in_reserve = storage.reserves.get(output_asset);
-
-        let bought = minimum_output_given_exact_input(exact_input, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
-
-        require(bought <= output_asset_in_reserve, TransactionError::InsufficientLiquidity);
+        let bought = minimum_output_given_exact_input(exact_input, input_asset.amount, output_asset.amount, LIQUIDITY_MINER_FEE);
 
         if min_output.is_some() {
             require(bought >= min_output.unwrap(), TransactionError::DesiredAmountTooHigh(min_output.unwrap()));
         }
 
-        transfer(bought, output_asset, sender);
-        storage.reserves.insert(input_asset, input_asset_in_reserve + exact_input);
-        storage.reserves.insert(output_asset, output_asset_in_reserve - bought);
+        transfer(bought, output_asset.id, msg_sender().unwrap());
+
+        input_asset.amount = input_asset.amount + exact_input;
+        output_asset.amount = output_asset.amount - bought;
+        storage.pair = Option::Some(AssetPair::new(input_asset, output_asset).sort(reserves.unwrap()));
 
         log(SwapEvent {
             input: input_asset,
             output: output_asset,
-            sold: exact_input,
-            bought,
         });
 
         bought
@@ -261,173 +248,151 @@ impl Exchange for Contract {
 
     #[storage(read, write)]
     fn swap_exact_output(output: u64, deadline: u64) -> u64 {
-        let input_asset = msg_asset_id();
-        let output_asset = determine_output_asset(input_asset, storage.pair);
+        let reserves = storage.pair;
+        let (mut input_asset, mut output_asset) = determine_assets(msg_asset_id(), reserves);
 
-        require(deadline > height(), InputError::DeadlinePassed);
-        require(output > 0, InputError::AmountCannotBeZero);
+        require(deadline > height(), InputError::DeadlinePassed(deadline));
+        require(output > 0, InputError::ExpectedNonZeroParameter(output_asset.id));
+        require(output <= output_asset.amount, TransactionError::InsufficientReserve(output_asset.id));
 
         let input_amount = msg_amount();
-        require(input_amount > 0, InputError::AmountCannotBeZero);
+        require(input_amount > 0, InputError::ExpectedNonZeroAmount(input_asset.id));
+
+        let sold = maximum_input_for_exact_output(output, input_asset.amount, output_asset.amount, LIQUIDITY_MINER_FEE);
+
+        require(sold > 0, TransactionError::DesiredAmountTooLow(output));
+        require(input_amount >= sold, TransactionError::DesiredAmountTooHigh(input_amount));
 
         let sender = msg_sender().unwrap();
-        let input_asset_in_reserve = storage.reserves.get(input_asset);
-        let output_asset_in_reserve = storage.reserves.get(output_asset);
-
-        require(output <= output_asset_in_reserve, TransactionError::InsufficientLiquidity);
-
-        let sold = maximum_input_for_exact_output(output, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
-
-        require(input_amount >= sold, TransactionError::ProvidedAmountTooLow(input_amount));
 
         let refund = input_amount - sold;
         if refund > 0 {
-            transfer(refund, input_asset, sender);
+            transfer(refund, input_asset.id, sender);
         };
 
-        transfer(output, output_asset, sender);
-        storage.reserves.insert(input_asset, input_asset_in_reserve + sold);
-        storage.reserves.insert(output_asset, output_asset_in_reserve - output);
+        transfer(output, output_asset.id, sender);
+
+        input_asset.amount = input_asset.amount + sold;
+        output_asset.amount = output_asset.amount - output;
+        storage.pair = Option::Some(AssetPair::new(input_asset, output_asset).sort(reserves.unwrap()));
 
         log(SwapEvent {
             input: input_asset,
             output: output_asset,
-            sold,
-            bought: output,
         });
 
         sold
     }
 
     #[storage(read, write)]
-    fn withdraw(amount: u64, asset: ContractId) {
-        require(storage.pair.is_some(), InitError::NotInitialized);
+    fn withdraw(asset: Asset) {
+        require(storage.pair.is_some(), InitError::AssetPairNotSet);
 
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
-
-        require(asset == asset_a_id || asset == asset_b_id, InputError::InvalidAsset);
+        require(asset.id == storage.pair.unwrap().a.id || asset.id == storage.pair.unwrap().b.id, InputError::InvalidAsset);
 
         let sender = msg_sender().unwrap();
-        let deposited_amount = storage.deposits.get((sender, asset));
+        let deposited_amount = storage.deposits.get((sender, asset.id));
 
-        require(deposited_amount >= amount, TransactionError::DesiredAmountTooHigh(amount));
+        require(deposited_amount >= asset.amount, TransactionError::DesiredAmountTooHigh(asset.amount));
 
-        let new_amount = deposited_amount - amount;
-        storage.deposits.insert((sender, asset), new_amount);
-        transfer(amount, asset, sender);
+        let new_amount = deposited_amount - asset.amount;
+        storage.deposits.insert((sender, asset.id), new_amount);
+        transfer(asset.amount, asset.id, sender);
 
         log(WithdrawEvent {
-            asset,
-            amount,
-            balance: new_amount,
+            withdrawn_asset: asset,
+            remaining_balance: new_amount,
         });
     }
 
     #[storage(read)]
-    fn balance(asset: ContractId) -> u64 {
-        require(storage.pair.is_some(), InitError::NotInitialized);
-        require(asset == storage.pair.unwrap().0 || asset == storage.pair.unwrap().1, InputError::InvalidAsset);
+    fn balance(asset_id: ContractId) -> u64 {
+        require(storage.pair.is_some(), InitError::AssetPairNotSet);
+        require(asset_id == storage.pair.unwrap().a.id || asset_id == storage.pair.unwrap().b.id, InputError::InvalidAsset);
 
-        let sender = msg_sender().unwrap();
-        storage.deposits.get((sender, asset))
+        storage.deposits.get((msg_sender().unwrap(), asset_id))
     }
 
     #[storage(read)]
     fn pool_info() -> PoolInfo {
-        require(storage.pair.is_some(), InitError::NotInitialized);
-
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
+        require(storage.pair.is_some(), InitError::AssetPairNotSet);
 
         PoolInfo {
-            asset_a: asset_a_id,
-            asset_b: asset_b_id,
-            asset_a_reserve: storage.reserves.get(asset_a_id),
-            asset_b_reserve: storage.reserves.get(asset_b_id),
+            reserves: storage.pair.unwrap(),
             liquidity: storage.liquidity_pool_supply,
         }
     }
 
     #[storage(read)]
-    fn preview_add_liquidity(amount: u64, asset: ContractId) -> PreviewAddLiquidityInfo {
-        require(storage.pair.is_some(), InitError::NotInitialized);
+    fn preview_add_liquidity(asset: Asset) -> PreviewAddLiquidityInfo {
+        require(storage.pair.is_some(), InitError::AssetPairNotSet);
 
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
+        let sender = msg_sender().unwrap();
         let total_liquidity = storage.liquidity_pool_supply;
-        let asset_a_in_reserve = storage.reserves.get(asset_a_id);
-        let asset_b_in_reserve = storage.reserves.get(asset_b_id);
+        let reserves = storage.pair.unwrap();
+        let deposits = AssetPair::new(Asset::new(reserves.a.id, storage.deposits.get((sender, reserves.a.id))), Asset::new(reserves.b.id, storage.deposits.get((sender, reserves.b.id))));
 
-        let asset_a_in_deposit = if asset == asset_a_id || asset_b_in_reserve == 0 {
-            amount
-        } else {
-            multiply_div(amount, asset_a_in_reserve, asset_b_in_reserve)
-        };
-        let asset_b_in_deposit = if asset == asset_b_id || asset_a_in_reserve == 0 {
-            amount
-        } else {
-            multiply_div(amount, asset_b_in_reserve, asset_a_in_reserve)
-        };
+        let mut added_assets = AssetPair::new(Asset::new(reserves.a.id, 0), Asset::new(reserves.b.id, 0));
+        let mut added_liquidity = 0;
 
-        let mut liquidity_to_add = 0;
-        let mut added_a = asset_a_in_deposit;
-        let mut added_b = asset_b_in_deposit;
-
-        if asset_a_in_reserve == 0 && asset_b_in_reserve == 0 {
-            liquidity_to_add = (asset_a_in_deposit * asset_b_in_deposit).sqrt();
+        if total_liquidity == 0 {
+            added_assets.a.amount = if deposits.a.amount == 0 {
+                asset.amount
+            } else {
+                deposits.a.amount
+            };
+            added_assets.b.amount = if deposits.b.amount == 0 {
+                asset.amount
+            } else {
+                deposits.b.amount
+            };
+            added_liquidity = (added_assets.a.amount * added_assets.b.amount).sqrt()
         } else {
-            let added_b = multiply_div(asset_a_in_deposit, asset_b_in_reserve, asset_a_in_reserve);
-            liquidity_to_add = multiply_div(added_b, total_liquidity, asset_b_in_reserve);
+            if asset.id == reserves.a.id {
+                added_assets.a.amount = asset.amount;
+                added_assets.b.amount = multiply_divide(asset.amount, reserves.b.amount, reserves.a.amount);
+            } else {
+                added_assets.a.amount = multiply_divide(asset.amount, reserves.a.amount, reserves.b.amount);
+                added_assets.b.amount = asset.amount;
+            }
+            added_liquidity = multiply_divide(added_assets.b.amount, total_liquidity, reserves.b.amount);
         }
 
         PreviewAddLiquidityInfo {
-            other_asset_amount_to_add: if asset == asset_a_id {
-                added_b
+            other_asset_to_add: if asset.id == reserves.a.id {
+                added_assets.b
             } else {
-                added_a
+                added_assets.a
             },
-            liquidity_asset_amount_to_receive: liquidity_to_add,
+            liquidity_asset_to_receive: Asset::new(contract_id(), added_liquidity),
         }
     }
 
     #[storage(read)]
-    fn preview_swap_exact_input(exact_input: u64, input_asset: ContractId) -> PreviewSwapInfo {
-        let output_asset = determine_output_asset(input_asset, storage.pair);
+    fn preview_swap_exact_input(exact_input_asset: Asset) -> PreviewSwapInfo {
+        let (input_asset, mut output_asset) = determine_assets(exact_input_asset.id, storage.pair);
 
-        let input_asset_in_reserve = storage.reserves.get(input_asset);
-        let output_asset_in_reserve = storage.reserves.get(output_asset);
-
-        let min_output = minimum_output_given_exact_input(exact_input, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
-        let sufficient_reserve = min_output <= output_asset_in_reserve;
+        output_asset.amount = minimum_output_given_exact_input(exact_input_asset.amount, input_asset.amount, output_asset.amount, LIQUIDITY_MINER_FEE);
+        let sufficient_reserve = output_asset.amount <= output_asset.amount;
 
         PreviewSwapInfo {
-            amount: min_output,
+            other_asset: output_asset,
             sufficient_reserve,
         }
     }
 
     #[storage(read)]
-    fn preview_swap_exact_output(exact_output: u64, output_asset: ContractId) -> PreviewSwapInfo {
-        require(storage.pair.is_some(), InitError::NotInitialized);
+    fn preview_swap_exact_output(exact_output_asset: Asset) -> PreviewSwapInfo {
+        let (output_asset, mut input_asset) = determine_assets(exact_output_asset.id, storage.pair);
 
-        let (asset_a_id, asset_b_id) = storage.pair.unwrap();
+        require(exact_output_asset.amount <= output_asset.amount, TransactionError::DesiredAmountTooHigh(exact_output_asset.amount));
 
-        require(output_asset == asset_a_id || output_asset == asset_b_id, InputError::InvalidAsset);
-
-        let input_asset = if output_asset == asset_a_id {
-            asset_b_id
-        } else {
-            asset_a_id
-        };
-
-        let input_asset_in_reserve = storage.reserves.get(input_asset);
-        let output_asset_in_reserve = storage.reserves.get(output_asset);
-
-        require(exact_output <= output_asset_in_reserve, TransactionError::DesiredAmountTooHigh(exact_output));
-
-        let max_input = maximum_input_for_exact_output(exact_output, input_asset_in_reserve, output_asset_in_reserve, LIQUIDITY_MINER_FEE);
-        let sufficient_reserve = exact_output <= output_asset_in_reserve;
+        input_asset.amount = maximum_input_for_exact_output(exact_output_asset.amount, input_asset.amount, output_asset.amount, LIQUIDITY_MINER_FEE);
+        require(input_asset.amount > 0, TransactionError::DesiredAmountTooLow(exact_output_asset.amount));
+        let sufficient_reserve = exact_output_asset.amount <= output_asset.amount;
 
         PreviewSwapInfo {
-            amount: max_input,
+            other_asset: input_asset,
             sufficient_reserve,
         }
     }

--- a/AMM/project/contracts/exchange-contract/src/utils.sw
+++ b/AMM/project/contracts/exchange-contract/src/utils.sw
@@ -3,6 +3,7 @@ library utils;
 dep errors;
 
 use core::primitives::*;
+use libraries::data_structures::{Asset, AssetPair};
 use errors::{InitError, InputError};
 use std::u128::U128;
 
@@ -11,13 +12,7 @@ fn calculate_amount_with_fee(amount: u64, liquidity_miner_fee: u64) -> u64 {
     amount - fee
 }
 
-pub fn div_multiply(a: u64, b: u64, c: u64) -> u64 {
-    let calculation = (U128::from((0, a)) / U128::from((0, b)));
-    let result_wrapped = (calculation * U128::from((0, c))).as_u64();
-    result_wrapped.unwrap()
-}
-
-/// Returns the maximum required amount of the input asset to get exactly ` output_amount ` of the output asset
+/// Returns the maximum required amount of the input asset to get exactly `output_amount` of the output asset
 pub fn maximum_input_for_exact_output(
     output_amount: u64,
     input_reserve: u64,
@@ -33,13 +28,13 @@ pub fn maximum_input_for_exact_output(
     let result_wrapped = (numerator / denominator).as_u64();
 
     if denominator > numerator {
-        u64::max()
+        0 // 0 < result < 1, round the result down since there are no floating points
     } else {
         result_wrapped.unwrap() + 1
     }
 }
 
-/// Given exactly ` input_amount ` of the input asset, returns the minimum resulting amount of the output asset
+/// Given exactly `input_amount` of the input asset, returns the minimum resulting amount of the output asset
 pub fn minimum_output_given_exact_input(
     input_amount: u64,
     input_reserve: u64,
@@ -54,22 +49,18 @@ pub fn minimum_output_given_exact_input(
     result_wrapped.unwrap()
 }
 
-pub fn multiply_div(a: u64, b: u64, c: u64) -> u64 {
+pub fn multiply_divide(a: u64, b: u64, c: u64) -> u64 {
     let calculation = (U128::from((0, a)) * U128::from((0, b)));
     let result_wrapped = (calculation / U128::from((0, c))).as_u64();
     result_wrapped.unwrap()
 }
 
-pub fn determine_output_asset(
-    input_asset: ContractId,
-    pair: Option<(ContractId, ContractId)>,
-) -> ContractId {
-    require(pair.is_some(), InitError::NotInitialized);
-    let (asset_a_id, asset_b_id) = pair.unwrap();
-    require(input_asset == asset_a_id || input_asset == asset_b_id, InputError::InvalidAsset);
-    if input_asset == asset_a_id {
-        asset_b_id
-    } else {
-        asset_a_id
-    }
+pub fn determine_assets(input_asset_id: ContractId, pair: Option<AssetPair>) -> (Asset, Asset) {
+    require(pair.is_some(), InitError::AssetPairNotSet);
+    let pair = pair.unwrap();
+    require(input_asset_id == pair.a.id || input_asset_id == pair.b.id, InputError::InvalidAsset);
+    (
+        pair.this_asset(input_asset_id),
+        pair.other_asset(input_asset_id),
+    )
 }

--- a/AMM/project/contracts/exchange-contract/tests/functions/add_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/add_liquidity.rs
@@ -1,69 +1,83 @@
-use crate::utils::{
-    abi_calls::{add_liquidity, pool_info},
-    test_helpers::{
-        contract_balances, deposit_and_add_liquidity, deposit_but_do_not_add_liquidity, setup,
-        setup_and_initialize, setup_initialize_and_deposit_but_do_not_add_liquidity,
-        setup_initialize_deposit_and_add_liquidity, wallet_balances,
-    },
-    LiquidityParameters,
+use crate::utils::setup_and_construct;
+use test_utils::{
+    data_structures::LiquidityParameters, interface::exchange::add_liquidity,
+    setup::common::deposit_and_add_liquidity,
 };
-use fuels::prelude::*;
 
 mod success {
     use super::*;
+    use crate::utils::{contract_balances, wallet_balances};
+    use test_utils::interface::exchange::{deposit, pool_info};
 
     #[tokio::test]
     async fn adds_when_liquidity_is_zero() {
-        let (exchange, wallet, amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
         let initial_contract_balances = contract_balances(&exchange).await;
 
-        deposit_but_do_not_add_liquidity(&amounts, &exchange).await;
+        deposit(
+            &exchange.instance,
+            liquidity_parameters.amounts.0,
+            exchange.pair.0,
+        )
+        .await;
+
+        deposit(
+            &exchange.instance,
+            liquidity_parameters.amounts.1,
+            exchange.pair.1,
+        )
+        .await;
 
         let contract_balances_after_deposit = contract_balances(&exchange).await;
 
         let added_liquidity = add_liquidity(
             &exchange.instance,
-            CallParameters::default(),
-            TxParameters::default(),
-            amounts.liquidity,
-            amounts.deadline,
+            liquidity_parameters.liquidity,
+            liquidity_parameters.deadline,
+            false,
         )
-        .await
-        .value;
+        .await;
 
-        let pool_info_after_adding_liquidity = pool_info(&exchange.instance).await.value;
+        let pool_info_after_adding_liquidity = pool_info(&exchange.instance).await;
         let wallet_balances_after_adding_liquidity = wallet_balances(&exchange, &wallet).await;
         let contract_balances_after_adding_liquidity = contract_balances(&exchange).await;
 
-        assert_eq!(initial_pool_info.asset_a_reserve, 0);
-        assert_eq!(initial_pool_info.asset_b_reserve, 0);
+        assert_eq!(initial_pool_info.reserves.a.amount, 0);
+        assert_eq!(initial_pool_info.reserves.b.amount, 0);
         assert_eq!(initial_pool_info.liquidity, 0);
         assert_eq!(initial_contract_balances.asset_a, 0);
         assert_eq!(initial_contract_balances.asset_b, 0);
-        assert_eq!(contract_balances_after_deposit.asset_a, amounts.amount_a);
-        assert_eq!(contract_balances_after_deposit.asset_b, amounts.amount_b);
-        assert_eq!(added_liquidity, amounts.liquidity);
         assert_eq!(
-            pool_info_after_adding_liquidity.asset_a_reserve,
-            amounts.amount_a
+            contract_balances_after_deposit.asset_a,
+            liquidity_parameters.amounts.0
         );
         assert_eq!(
-            pool_info_after_adding_liquidity.asset_b_reserve,
-            amounts.amount_b
+            contract_balances_after_deposit.asset_b,
+            liquidity_parameters.amounts.1
+        );
+        assert_eq!(added_liquidity, liquidity_parameters.liquidity);
+        assert_eq!(
+            pool_info_after_adding_liquidity.reserves.a.amount,
+            liquidity_parameters.amounts.0
+        );
+        assert_eq!(
+            pool_info_after_adding_liquidity.reserves.b.amount,
+            liquidity_parameters.amounts.1
         );
         assert_eq!(pool_info_after_adding_liquidity.liquidity, added_liquidity);
         assert_eq!(contract_balances_after_adding_liquidity.asset_a, 0);
         assert_eq!(contract_balances_after_adding_liquidity.asset_b, 0);
         assert_eq!(
             wallet_balances_after_adding_liquidity.asset_a,
-            initial_wallet_balances.asset_a - amounts.amount_a
+            initial_wallet_balances.asset_a - liquidity_parameters.amounts.0
         );
         assert_eq!(
             wallet_balances_after_adding_liquidity.asset_b,
-            initial_wallet_balances.asset_b - amounts.amount_b
+            initial_wallet_balances.asset_b - liquidity_parameters.amounts.1
         );
         assert_eq!(
             wallet_balances_after_adding_liquidity.liquidity_pool_asset,
@@ -73,31 +87,35 @@ mod success {
 
     #[tokio::test]
     async fn adds_when_liquidity_exists_based_on_a_and_refunds() {
-        let (exchange, wallet, amounts, _asset_c_id) = setup_and_initialize().await;
-        let second_liquidity_amounts = LiquidityParameters {
-            amount_a: amounts.amount_a,
-            amount_b: amounts.amount_b * 2,
-            deadline: amounts.deadline,
-            liquidity: amounts.liquidity,
-        };
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
+        let second_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                liquidity_parameters.amounts.0,
+                liquidity_parameters.amounts.1 * 2,
+            )),
+            Some(liquidity_parameters.deadline),
+            Some(liquidity_parameters.liquidity),
+        );
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
         let initial_contract_balances = contract_balances(&exchange).await;
 
-        deposit_and_add_liquidity(&amounts, &exchange).await;
+        deposit_and_add_liquidity(&liquidity_parameters, &exchange, false).await;
 
         let contract_balances_after_adding_liquidity_for_the_first_time =
             contract_balances(&exchange).await;
 
-        let added_liquidity = deposit_and_add_liquidity(&second_liquidity_amounts, &exchange).await;
+        let added_liquidity =
+            deposit_and_add_liquidity(&second_liquidity_parameters, &exchange, true).await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_contract_balances = contract_balances(&exchange).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
-        assert_eq!(initial_pool_info.asset_a_reserve, 0);
-        assert_eq!(initial_pool_info.asset_b_reserve, 0);
+        assert_eq!(initial_pool_info.reserves.a.amount, 0);
+        assert_eq!(initial_pool_info.reserves.b.amount, 0);
         assert_eq!(initial_pool_info.liquidity, 0);
         assert_eq!(initial_contract_balances.asset_a, 0);
         assert_eq!(initial_contract_balances.asset_b, 0);
@@ -109,64 +127,69 @@ mod success {
             contract_balances_after_adding_liquidity_for_the_first_time.asset_b,
             0
         );
-        assert_eq!(added_liquidity, second_liquidity_amounts.liquidity);
+        assert_eq!(added_liquidity, second_liquidity_parameters.liquidity);
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            amounts.amount_a + second_liquidity_amounts.amount_a
+            final_pool_info.reserves.a.amount,
+            liquidity_parameters.amounts.0 + second_liquidity_parameters.amounts.0
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            amounts.amount_b + (second_liquidity_amounts.amount_b / 2)
+            final_pool_info.reserves.b.amount,
+            liquidity_parameters.amounts.1 + (second_liquidity_parameters.amounts.1 / 2)
         );
         assert_eq!(
             final_pool_info.liquidity,
-            amounts.liquidity + added_liquidity
+            liquidity_parameters.liquidity + added_liquidity
         );
         assert_eq!(final_contract_balances.asset_a, 0);
         assert_eq!(final_contract_balances.asset_b, 0);
         assert_eq!(
             final_wallet_balances.asset_a,
             initial_wallet_balances.asset_a
-                - (amounts.amount_a + second_liquidity_amounts.amount_a)
+                - (liquidity_parameters.amounts.0 + second_liquidity_parameters.amounts.0)
         );
         assert_eq!(
             final_wallet_balances.asset_b,
             initial_wallet_balances.asset_b
-                - (amounts.amount_b + (second_liquidity_amounts.amount_b / 2))
+                - (liquidity_parameters.amounts.1 + (second_liquidity_parameters.amounts.1 / 2))
         );
         assert_eq!(
             final_wallet_balances.liquidity_pool_asset,
             initial_wallet_balances.liquidity_pool_asset
-                + (amounts.liquidity + second_liquidity_amounts.liquidity)
+                + (liquidity_parameters.liquidity + second_liquidity_parameters.liquidity)
         );
     }
 
     #[tokio::test]
     async fn adds_when_liquidity_exists_based_on_b_and_refunds() {
-        let (exchange, wallet, amounts, _asset_c_id) = setup_and_initialize().await;
-        let second_liquidity_amounts = LiquidityParameters {
-            amount_a: amounts.amount_a * 2,
-            amount_b: amounts.amount_b,
-            deadline: amounts.deadline,
-            liquidity: amounts.liquidity,
-        };
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
+        let second_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                liquidity_parameters.amounts.0 * 2,
+                liquidity_parameters.amounts.1,
+            )),
+            Some(liquidity_parameters.deadline),
+            Some(liquidity_parameters.liquidity),
+        );
+
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
         let initial_contract_balances = contract_balances(&exchange).await;
 
-        deposit_and_add_liquidity(&amounts, &exchange).await;
+        deposit_and_add_liquidity(&liquidity_parameters, &exchange, false).await;
 
         let contract_balances_after_adding_liquidity_for_the_first_time =
             contract_balances(&exchange).await;
 
-        let added_liquidity = deposit_and_add_liquidity(&second_liquidity_amounts, &exchange).await;
+        let added_liquidity =
+            deposit_and_add_liquidity(&second_liquidity_parameters, &exchange, true).await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_contract_balances = contract_balances(&exchange).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
-        assert_eq!(initial_pool_info.asset_a_reserve, 0);
-        assert_eq!(initial_pool_info.asset_b_reserve, 0);
+        assert_eq!(initial_pool_info.reserves.a.amount, 0);
+        assert_eq!(initial_pool_info.reserves.b.amount, 0);
         assert_eq!(initial_pool_info.liquidity, 0);
         assert_eq!(initial_contract_balances.asset_a, 0);
         assert_eq!(initial_contract_balances.asset_b, 0);
@@ -178,186 +201,200 @@ mod success {
             contract_balances_after_adding_liquidity_for_the_first_time.asset_b,
             0
         );
-        assert_eq!(added_liquidity, second_liquidity_amounts.liquidity);
+        assert_eq!(added_liquidity, second_liquidity_parameters.liquidity);
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            amounts.amount_a + (second_liquidity_amounts.amount_a / 2)
+            final_pool_info.reserves.a.amount,
+            liquidity_parameters.amounts.0 + (second_liquidity_parameters.amounts.0 / 2)
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            amounts.amount_b + second_liquidity_amounts.amount_b
+            final_pool_info.reserves.b.amount,
+            liquidity_parameters.amounts.1 + second_liquidity_parameters.amounts.1
         );
         assert_eq!(
             final_pool_info.liquidity,
-            amounts.liquidity + added_liquidity
+            liquidity_parameters.liquidity + added_liquidity
         );
         assert_eq!(final_contract_balances.asset_a, 0);
         assert_eq!(final_contract_balances.asset_b, 0);
         assert_eq!(
             final_wallet_balances.asset_a,
             initial_wallet_balances.asset_a
-                - (amounts.amount_a + (second_liquidity_amounts.amount_a / 2))
+                - (liquidity_parameters.amounts.0 + (second_liquidity_parameters.amounts.0 / 2))
         );
         assert_eq!(
             final_wallet_balances.asset_b,
             initial_wallet_balances.asset_b
-                - (amounts.amount_b + second_liquidity_amounts.amount_b)
+                - (liquidity_parameters.amounts.1 + second_liquidity_parameters.amounts.1)
         );
         assert_eq!(
             final_wallet_balances.liquidity_pool_asset,
             initial_wallet_balances.liquidity_pool_asset
-                + (amounts.liquidity + second_liquidity_amounts.liquidity)
+                + (liquidity_parameters.liquidity + second_liquidity_parameters.liquidity)
         );
     }
 }
 
 mod revert {
     use super::*;
+    use crate::utils::setup;
+    use fuels::prelude::CallParameters;
 
     #[tokio::test]
-    #[should_panic(expected = "NotInitialized")]
-    async fn when_unitialized() {
-        // call setup instead of setup_and_initialize
-        let (exchange_instance, _wallet, _pool_asset_id, _asset_a_id, _asset_b_id, _asset_c_id) =
-            setup().await;
-        let min_liquidity = 200;
-        let deadline = 1000;
+    #[should_panic(expected = "AssetPairNotSet")]
+    async fn when_uninitialized() {
+        // call setup instead of setup_and_construct
+        let (exchange_instance, _wallet, _assets, deadline) = setup().await;
+        let min_liquidity = 20000;
 
-        add_liquidity(
-            &exchange_instance,
-            CallParameters::default(),
-            TxParameters::default(),
-            min_liquidity,
-            deadline,
-        )
-        .await;
+        add_liquidity(&exchange_instance, min_liquidity, deadline, false).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "DeadlinePassed")]
-    async fn when_deadline_has_passed() {
-        let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
+    async fn when_deadline_passed() {
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
 
-        let override_amounts = LiquidityParameters {
-            amount_a: amounts.amount_a,
-            amount_b: amounts.amount_b,
-            deadline: 0, // deadline too low
-            liquidity: amounts.liquidity,
-        };
+        let override_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                liquidity_parameters.amounts.0,
+                liquidity_parameters.amounts.1,
+            )),
+            Some(0), // deadline too low
+            Some(liquidity_parameters.liquidity),
+        );
 
-        deposit_and_add_liquidity(&override_amounts, &exchange).await;
+        deposit_and_add_liquidity(&override_liquidity_parameters, &exchange, false).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "AmountMustBeZero")]
+    #[should_panic(expected = "ExpectedZeroAmount")]
     async fn when_msg_amount_is_not_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id) =
-            setup_initialize_and_deposit_but_do_not_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, false).await;
 
-        add_liquidity(
-            &exchange.instance,
-            CallParameters::new(
-                // msg_amount not zero
-                Some(1),
-                None,
-                None,
-            ),
-            TxParameters::default(),
-            amounts.liquidity,
-            amounts.deadline,
-        )
-        .await;
+        exchange
+            .instance
+            .methods()
+            .add_liquidity(
+                liquidity_parameters.liquidity,
+                liquidity_parameters.deadline,
+            )
+            // `add_liquidity` adds liquidity by using up at least one of the assets
+            // one variable output is for the minted liquidity pool asset
+            // the other variable output is for the asset that is not used up
+            .append_variable_outputs(2)
+            .call_params(CallParameters::new(Some(1), None, None))
+            .call()
+            .await
+            .unwrap();
     }
 
     #[tokio::test]
-    #[should_panic(expected = "AmountTooLow")]
+    #[should_panic(expected = "CannotAddLessThanMinimumLiquidity")]
     async fn when_desired_liquidity_is_less_than_minimum_liquidity() {
-        let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
 
-        let override_amounts = LiquidityParameters {
-            amount_a: amounts.amount_a,
-            amount_b: amounts.amount_b,
-            deadline: amounts.deadline,
-            liquidity: 0, // expected_liquidity is less than MINIMUM_LIQUIDITY
-        };
+        let override_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                liquidity_parameters.amounts.0,
+                liquidity_parameters.amounts.1,
+            )),
+            Some(liquidity_parameters.deadline),
+            Some(0), // expected_liquidity is less than MINIMUM_LIQUIDITY
+        );
 
-        deposit_and_add_liquidity(&override_amounts, &exchange).await;
+        deposit_and_add_liquidity(&override_liquidity_parameters, &exchange, false).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "DepositCannotBeZero")]
+    #[should_panic(expected = "ExpectedNonZeroDeposit")]
     async fn when_deposited_a_is_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
 
-        let override_amounts = LiquidityParameters {
-            amount_a: 0, // depositing 0 amount of asset A
-            amount_b: amounts.amount_b,
-            deadline: amounts.deadline,
-            liquidity: amounts.liquidity,
-        };
+        let override_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                0, // depositing 0 amount of asset A
+                liquidity_parameters.amounts.1,
+            )),
+            Some(liquidity_parameters.deadline),
+            Some(liquidity_parameters.liquidity),
+        );
 
-        deposit_and_add_liquidity(&override_amounts, &exchange).await;
+        deposit_and_add_liquidity(&override_liquidity_parameters, &exchange, false).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "DepositCannotBeZero")]
+    #[should_panic(expected = "ExpectedNonZeroDeposit")]
     async fn when_deposited_b_is_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
 
-        let override_amounts = LiquidityParameters {
-            amount_a: amounts.amount_a,
-            amount_b: 0, // depositing 0 amount of asset B
-            deadline: amounts.deadline,
-            liquidity: amounts.liquidity,
-        };
+        let override_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                liquidity_parameters.amounts.0,
+                0, // depositing 0 amount of asset B
+            )),
+            Some(liquidity_parameters.deadline),
+            Some(liquidity_parameters.liquidity),
+        );
 
-        deposit_and_add_liquidity(&override_amounts, &exchange).await;
+        deposit_and_add_liquidity(&override_liquidity_parameters, &exchange, false).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_liquidity_is_zero_but_desired_liquidity_is_too_high() {
-        let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
 
-        let override_amounts = LiquidityParameters {
-            amount_a: amounts.amount_a,
-            amount_b: amounts.amount_b,
-            deadline: amounts.deadline,
-            liquidity: 300, // expected_liquidity is more than 200
-        };
+        let override_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                liquidity_parameters.amounts.0,
+                liquidity_parameters.amounts.1,
+            )),
+            Some(liquidity_parameters.deadline),
+            Some(liquidity_parameters.liquidity + 100), // expected_liquidity is more than what can be provided with this setup
+        );
 
-        deposit_and_add_liquidity(&override_amounts, &exchange).await;
+        deposit_and_add_liquidity(&override_liquidity_parameters, &exchange, false).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_liquidity_exists_but_desired_liquidity_is_too_high_based_on_a() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let override_amounts = LiquidityParameters {
-            amount_a: amounts.amount_a,
-            amount_b: amounts.amount_b * 2, // setting this so that liquidity is calculated based on asset A amount
-            deadline: amounts.deadline,
-            liquidity: amounts.liquidity * 2, // expected_liquidity is more than 200
-        };
+        let override_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                liquidity_parameters.amounts.0,
+                liquidity_parameters.amounts.1 * 2, // setting this so that liquidity is calculated based on asset A amount
+            )),
+            Some(liquidity_parameters.deadline),
+            Some(liquidity_parameters.liquidity * 2), // expected_liquidity is more than what can be provided with this setup
+        );
 
-        deposit_and_add_liquidity(&override_amounts, &exchange).await;
+        deposit_and_add_liquidity(&override_liquidity_parameters, &exchange, true).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_liquidity_exists_but_desired_liquidity_is_too_high_based_on_b() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let override_amounts = LiquidityParameters {
-            amount_a: amounts.amount_a * 2, // setting this so that liquidity is calculated based on asset B amount
-            amount_b: amounts.amount_b,
-            deadline: amounts.deadline,
-            liquidity: amounts.liquidity * 2, // expected_liquidity is more than 200
-        };
+        let override_liquidity_parameters = LiquidityParameters::new(
+            Some((
+                liquidity_parameters.amounts.0 * 2, // setting this so that liquidity is calculated based on asset B amount
+                liquidity_parameters.amounts.1,
+            )),
+            Some(liquidity_parameters.deadline),
+            Some(liquidity_parameters.liquidity * 2), // expected_liquidity is more than what can be provided with this setup
+        );
 
-        deposit_and_add_liquidity(&override_amounts, &exchange).await;
+        deposit_and_add_liquidity(&override_liquidity_parameters, &exchange, true).await;
     }
 }

--- a/AMM/project/contracts/exchange-contract/tests/functions/balance.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/balance.rs
@@ -1,33 +1,31 @@
-use crate::utils::{
-    abi_calls::{balance, deposit},
-    test_helpers::{setup, setup_and_initialize},
-};
-use fuels::prelude::*;
+use crate::utils::setup_and_construct;
+use test_utils::interface::exchange::balance;
 
 mod success {
     use super::*;
+    use test_utils::interface::exchange::deposit;
 
     #[tokio::test]
     async fn returns_zero() {
-        let (exchange, _wallet, _amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, _wallet, _liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
 
-        let balance = balance(&exchange.instance, exchange.asset_a).await.value;
+        let balance = balance(&exchange.instance, exchange.pair.0).await;
 
         assert_eq!(balance, 0);
     }
 
     #[tokio::test]
     async fn returns_non_zero() {
-        let (exchange, _wallet, _amounts, _asset_c_id) = setup_and_initialize().await;
-        let initial_balance = balance(&exchange.instance, exchange.asset_a).await.value;
+        let (exchange, _wallet, _liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
+        let initial_balance = balance(&exchange.instance, exchange.pair.0).await;
+
         let deposit_amount = 10;
 
-        deposit(
-            &exchange.instance,
-            CallParameters::new(Some(deposit_amount), Some(exchange.asset_a), None),
-        )
-        .await;
-        let balance = balance(&exchange.instance, exchange.asset_a).await.value;
+        deposit(&exchange.instance, deposit_amount, exchange.pair.0).await;
+
+        let balance = balance(&exchange.instance, exchange.pair.0).await;
 
         assert_eq!(initial_balance, 0);
         assert_eq!(balance, deposit_amount);
@@ -36,21 +34,22 @@ mod success {
 
 mod revert {
     use super::*;
+    use crate::utils::setup;
 
     #[tokio::test]
-    #[should_panic(expected = "NotInitialized")]
-    async fn when_unitialized() {
-        // call setup instead of setup_and_initialize
-        let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
-            setup().await;
+    #[should_panic(expected = "AssetPairNotSet")]
+    async fn when_uninitialized() {
+        // call setup instead of setup_and_construct
+        let (exchange_instance, _wallet, assets, _deadline) = setup().await;
 
-        balance(&exchange_instance, asset_a_id).await;
+        balance(&exchange_instance, assets.asset_1).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
-        let (exchange, _wallet, _amounts, asset_c_id) = setup_and_initialize().await;
+        let (exchange, _wallet, _liquidity_parameters, asset_c_id) =
+            setup_and_construct(false, false).await;
 
         // send invalid asset id
         balance(&exchange.instance, asset_c_id).await;

--- a/AMM/project/contracts/exchange-contract/tests/functions/constructor.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/constructor.rs
@@ -1,22 +1,20 @@
-use crate::utils::{
-    abi_calls::{constructor, pool_info},
-    test_helpers::setup,
-};
-use fuels::prelude::*;
+use crate::utils::setup;
+use test_utils::interface::exchange::constructor;
 
 mod success {
     use super::*;
+    use fuels::prelude::ContractId;
+    use test_utils::interface::exchange::pool_info;
 
     #[tokio::test]
     async fn constructs() {
-        let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, asset_b_id, _asset_c_id) =
-            setup().await;
+        let (exchange_instance, _wallet, assets, _deadline) = setup().await;
 
-        constructor(&exchange_instance, (asset_a_id, asset_b_id)).await;
-        let pool_info = pool_info(&exchange_instance).await.value;
+        constructor(&exchange_instance, (assets.asset_1, assets.asset_2)).await;
+        let pool_info = pool_info(&exchange_instance).await;
 
-        assert_eq!(pool_info.asset_a, ContractId::new(*asset_a_id));
-        assert_eq!(pool_info.asset_b, ContractId::new(*asset_b_id));
+        assert_eq!(pool_info.reserves.a.id, ContractId::new(*assets.asset_1));
+        assert_eq!(pool_info.reserves.b.id, ContractId::new(*assets.asset_2));
     }
 }
 
@@ -24,21 +22,20 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    #[should_panic(expected = "CannotReinitialize")]
+    #[should_panic(expected = "AssetPairAlreadySet")]
     async fn when_reinitialized() {
-        let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, asset_b_id, _asset_c_id) =
-            setup().await;
+        let (exchange_instance, _wallet, assets, _deadline) = setup().await;
 
-        constructor(&exchange_instance, (asset_a_id, asset_b_id)).await;
-        constructor(&exchange_instance, (asset_a_id, asset_b_id)).await;
+        constructor(&exchange_instance, (assets.asset_1, assets.asset_2)).await;
+
+        constructor(&exchange_instance, (assets.asset_1, assets.asset_2)).await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "PoolAssetsCannotBeIdentical")]
+    #[should_panic(expected = "IdenticalAssets")]
     async fn when_assets_in_pair_are_identical() {
-        let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
-            setup().await;
+        let (exchange_instance, _wallet, assets, _deadline) = setup().await;
 
-        constructor(&exchange_instance, (asset_a_id, asset_a_id)).await;
+        constructor(&exchange_instance, (assets.asset_1, assets.asset_1)).await;
     }
 }

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_input.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_input.rs
@@ -1,28 +1,35 @@
-use crate::utils::{
-    abi_calls::preview_swap_exact_input,
-    test_helpers::{setup, setup_initialize_deposit_and_add_liquidity},
-};
+use crate::utils::setup_and_construct;
+use test_utils::interface::exchange::preview_swap_exact_input;
 
 mod success {
     use super::*;
+    use fuels::prelude::AssetId;
 
     #[tokio::test]
     async fn previews_swap_of_a() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
+
         let input_amount = 10;
 
         // hardcoded calculation for liquidity miner fee of 333
-        let expected_min_output_amount = (input_amount * (1 - (1 / 333)) * amounts.amount_b)
-            / (amounts.amount_a + (input_amount * (1 - (1 / 333))));
-        let expected_sufficient_reserve = expected_min_output_amount <= amounts.amount_b;
+        let expected_min_output_amount =
+            (input_amount * (1 - (1 / 333)) * liquidity_parameters.amounts.1)
+                / (liquidity_parameters.amounts.0 + (input_amount * (1 - (1 / 333))));
+        let expected_sufficient_reserve =
+            expected_min_output_amount <= liquidity_parameters.amounts.1;
 
         let preview_swap_info =
-            preview_swap_exact_input(&exchange.instance, input_amount, exchange.asset_a)
-                .await
-                .value;
+            preview_swap_exact_input(&exchange.instance, input_amount, exchange.pair.0, true).await;
 
-        assert_eq!(preview_swap_info.amount, expected_min_output_amount);
+        assert_eq!(
+            AssetId::new(*preview_swap_info.other_asset.id),
+            exchange.pair.1
+        );
+        assert_eq!(
+            preview_swap_info.other_asset.amount,
+            expected_min_output_amount
+        );
         assert_eq!(
             preview_swap_info.sufficient_reserve,
             expected_sufficient_reserve
@@ -31,21 +38,28 @@ mod success {
 
     #[tokio::test]
     async fn previews_swap_of_b() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
         let input_amount = 10;
 
         // hardcoded calculation for liquidity miner fee of 333
-        let expected_min_output_amount = (input_amount * (1 - (1 / 333)) * amounts.amount_a)
-            / (amounts.amount_b + (input_amount * (1 - (1 / 333))));
-        let expected_sufficient_reserve = expected_min_output_amount <= amounts.amount_a;
+        let expected_min_output_amount =
+            (input_amount * (1 - (1 / 333)) * liquidity_parameters.amounts.0)
+                / (liquidity_parameters.amounts.1 + (input_amount * (1 - (1 / 333))));
+        let expected_sufficient_reserve =
+            expected_min_output_amount <= liquidity_parameters.amounts.0;
 
         let preview_swap_info =
-            preview_swap_exact_input(&exchange.instance, input_amount, exchange.asset_b)
-                .await
-                .value;
+            preview_swap_exact_input(&exchange.instance, input_amount, exchange.pair.1, true).await;
 
-        assert_eq!(preview_swap_info.amount, expected_min_output_amount);
+        assert_eq!(
+            AssetId::new(*preview_swap_info.other_asset.id),
+            exchange.pair.0
+        );
+        assert_eq!(
+            preview_swap_info.other_asset.amount,
+            expected_min_output_amount
+        );
         assert_eq!(
             preview_swap_info.sufficient_reserve,
             expected_sufficient_reserve
@@ -55,28 +69,29 @@ mod success {
 
 mod revert {
     use super::*;
+    use crate::utils::setup;
 
     #[tokio::test]
-    #[should_panic(expected = "NotInitialized")]
-    async fn when_unitialized() {
-        // call setup instead of setup_and_initialize
-        let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
-            setup().await;
+    #[should_panic(expected = "AssetPairNotSet")]
+    async fn when_uninitialized() {
+        // call setup instead of setup_and_construct
+        let (exchange_instance, _wallet, assets, _deadline) = setup().await;
 
-        preview_swap_exact_input(&exchange_instance, 10, asset_a_id).await;
+        preview_swap_exact_input(&exchange_instance, 10, assets.asset_1, false).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
-        let (exchange, _wallet, _amounts, asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, _liquidity_parameters, asset_c_id) =
+            setup_and_construct(true, true).await;
 
         preview_swap_exact_input(
             &exchange.instance,
             10,
-            // sending invalid asset
+            // passing invalid asset
             asset_c_id,
+            false,
         )
         .await;
     }

--- a/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_output.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/preview_swap_exact_output.rs
@@ -1,31 +1,36 @@
-use crate::utils::{
-    abi_calls::preview_swap_exact_output,
-    test_helpers::{setup, setup_initialize_deposit_and_add_liquidity},
-};
+use crate::utils::setup_and_construct;
+use test_utils::interface::exchange::preview_swap_exact_output;
 
 mod success {
     use super::*;
+    use fuels::prelude::AssetId;
 
     #[tokio::test]
     async fn previews_swap_of_a() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
         // hardcoded calculation for liquidity miner fee of 333
-        let expected_max_input_amount = ((amounts.amount_a * output_amount)
-            / (amounts.amount_b - output_amount)
+        let expected_max_input_amount = ((liquidity_parameters.amounts.0 * output_amount)
+            / (liquidity_parameters.amounts.1 - output_amount)
             * (1 - (1 / 333)))
             + 1;
-        let expected_sufficient_reserve = output_amount < amounts.amount_b;
+        let expected_sufficient_reserve = output_amount < liquidity_parameters.amounts.1;
 
         let preview_swap_info =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_b)
-                .await
-                .value;
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.1, true)
+                .await;
 
-        assert_eq!(preview_swap_info.amount, expected_max_input_amount);
+        assert_eq!(
+            AssetId::new(*preview_swap_info.other_asset.id),
+            exchange.pair.0
+        );
+        assert_eq!(
+            preview_swap_info.other_asset.amount,
+            expected_max_input_amount
+        );
         assert_eq!(
             preview_swap_info.sufficient_reserve,
             expected_sufficient_reserve
@@ -34,24 +39,30 @@ mod success {
 
     #[tokio::test]
     async fn previews_swap_of_b() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
         // hardcoded calculation for liquidity miner fee of 333
-        let expected_max_input_amount = ((amounts.amount_b * output_amount)
-            / (amounts.amount_a - output_amount)
+        let expected_max_input_amount = ((liquidity_parameters.amounts.1 * output_amount)
+            / (liquidity_parameters.amounts.0 - output_amount)
             * (1 - (1 / 333)))
             + 1;
-        let expected_sufficient_reserve = output_amount <= amounts.amount_a;
+        let expected_sufficient_reserve = output_amount <= liquidity_parameters.amounts.0;
 
         let preview_swap_info =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_a)
-                .await
-                .value;
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.0, true)
+                .await;
 
-        assert_eq!(preview_swap_info.amount, expected_max_input_amount);
+        assert_eq!(
+            AssetId::new(*preview_swap_info.other_asset.id),
+            exchange.pair.1
+        );
+        assert_eq!(
+            preview_swap_info.other_asset.amount,
+            expected_max_input_amount
+        );
         assert_eq!(
             preview_swap_info.sufficient_reserve,
             expected_sufficient_reserve
@@ -60,24 +71,30 @@ mod success {
 
     #[tokio::test]
     async fn previews_maximum_swap_of_a() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let output_amount = amounts.amount_b - 1;
+        let output_amount = liquidity_parameters.amounts.1 - 1;
 
         // hardcoded calculation for liquidity miner fee of 333
-        let expected_max_input_amount = ((amounts.amount_a * output_amount)
-            / (amounts.amount_b - output_amount)
+        let expected_max_input_amount = ((liquidity_parameters.amounts.0 * output_amount)
+            / (liquidity_parameters.amounts.1 - output_amount)
             * (1 - (1 / 333)))
             + 1;
-        let expected_sufficient_reserve = output_amount < amounts.amount_b;
+        let expected_sufficient_reserve = output_amount < liquidity_parameters.amounts.1;
 
         let preview_swap_info =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_b)
-                .await
-                .value;
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.1, true)
+                .await;
 
-        assert_eq!(preview_swap_info.amount, expected_max_input_amount);
+        assert_eq!(
+            AssetId::new(*preview_swap_info.other_asset.id),
+            exchange.pair.0
+        );
+        assert_eq!(
+            preview_swap_info.other_asset.amount,
+            expected_max_input_amount
+        );
         assert_eq!(
             preview_swap_info.sufficient_reserve,
             expected_sufficient_reserve
@@ -86,24 +103,30 @@ mod success {
 
     #[tokio::test]
     async fn previews_maximum_swap_of_b() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let output_amount = amounts.amount_a - 1;
+        let output_amount = liquidity_parameters.amounts.0 - 1;
 
         // hardcoded calculation for liquidity miner fee of 333
-        let expected_max_input_amount = ((amounts.amount_b * output_amount)
-            / (amounts.amount_a - output_amount)
+        let expected_max_input_amount = ((liquidity_parameters.amounts.1 * output_amount)
+            / (liquidity_parameters.amounts.0 - output_amount)
             * (1 - (1 / 333)))
             + 1;
-        let expected_sufficient_reserve = output_amount < amounts.amount_a;
+        let expected_sufficient_reserve = output_amount < liquidity_parameters.amounts.0;
 
         let preview_swap_info =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_a)
-                .await
-                .value;
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.0, true)
+                .await;
 
-        assert_eq!(preview_swap_info.amount, expected_max_input_amount);
+        assert_eq!(
+            AssetId::new(*preview_swap_info.other_asset.id),
+            exchange.pair.1
+        );
+        assert_eq!(
+            preview_swap_info.other_asset.amount,
+            expected_max_input_amount
+        );
         assert_eq!(
             preview_swap_info.sufficient_reserve,
             expected_sufficient_reserve
@@ -113,28 +136,29 @@ mod success {
 
 mod revert {
     use super::*;
+    use crate::utils::setup;
 
     #[tokio::test]
-    #[should_panic(expected = "NotInitialized")]
-    async fn when_unitialized() {
-        // call setup instead of setup_and_initialize
-        let (exchange_instance, _wallet, _pool_asset_id, _asset_a_id, asset_b_id, _asset_c_id) =
-            setup().await;
+    #[should_panic(expected = "AssetPairNotSet")]
+    async fn when_uninitialized() {
+        // call setup instead of setup_and_construct
+        let (exchange_instance, _wallet, assets, _deadline) = setup().await;
 
-        preview_swap_exact_output(&exchange_instance, 10, asset_b_id).await;
+        preview_swap_exact_output(&exchange_instance, 10, assets.asset_1, false).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
-        let (exchange, _wallet, _amounts, asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, _liquidity_parameters, asset_c_id) =
+            setup_and_construct(true, true).await;
 
         preview_swap_exact_output(
             &exchange.instance,
             10,
-            // sending invalid asset
+            // passing invalid asset
             asset_c_id,
+            false,
         )
         .await;
     }
@@ -142,22 +166,22 @@ mod revert {
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_output_b_amount_is_greater_than_reserve() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let output_amount = amounts.amount_b + 1;
+        let output_amount = liquidity_parameters.amounts.1 + 1;
 
-        preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_b).await;
+        preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.1, false).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_output_a_amount_is_greater_than_reserve() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let output_amount = amounts.amount_a + 1;
+        let output_amount = liquidity_parameters.amounts.0 + 1;
 
-        preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_a).await;
+        preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.0, false).await;
     }
 }

--- a/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/remove_liquidity.rs
@@ -1,49 +1,51 @@
-use crate::utils::{
-    abi_calls::{pool_info, remove_liquidity},
-    test_helpers::{
-        setup, setup_and_initialize, setup_initialize_deposit_and_add_liquidity, wallet_balances,
-    },
-};
-use fuels::prelude::*;
+use crate::utils::setup_and_construct;
+use test_utils::interface::exchange::{pool_info, remove_liquidity};
 
 mod success {
     use super::*;
+    use crate::utils::wallet_balances;
 
     #[tokio::test]
     async fn removes_all_liquidity_passing_exact_a_and_b_values() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let liquidity_to_remove = amounts.liquidity;
-        let a_to_remove = amounts.amount_a;
-        let b_to_remove = amounts.amount_b;
-        let expected_liquidity_removed = amounts.liquidity;
-        let expected_a_removed = amounts.amount_a;
-        let expected_b_removed = amounts.amount_b;
+        let liquidity_to_remove = liquidity_parameters.liquidity;
+        let a_to_remove = liquidity_parameters.amounts.0;
+        let b_to_remove = liquidity_parameters.amounts.1;
+        let expected_liquidity_removed = liquidity_parameters.liquidity;
+        let expected_a_removed = liquidity_parameters.amounts.0;
+        let expected_b_removed = liquidity_parameters.amounts.1;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let remove_liquidity_info = remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(liquidity_to_remove),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
+            exchange.id,
+            liquidity_to_remove,
             a_to_remove,
             b_to_remove,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
-        assert_eq!(remove_liquidity_info.asset_a_amount, expected_a_removed);
-        assert_eq!(remove_liquidity_info.asset_b_amount, expected_b_removed);
-        assert_eq!(remove_liquidity_info.liquidity, expected_liquidity_removed);
+        assert_eq!(
+            remove_liquidity_info.removed_amounts.a.amount,
+            expected_a_removed
+        );
+        assert_eq!(
+            remove_liquidity_info.removed_amounts.b.amount,
+            expected_b_removed
+        );
+        assert_eq!(
+            remove_liquidity_info.burned_liquidity.amount,
+            expected_liquidity_removed
+        );
         assert_eq!(
             final_wallet_balances.asset_a,
             initial_wallet_balances.asset_a + expected_a_removed
@@ -57,12 +59,12 @@ mod success {
             initial_wallet_balances.liquidity_pool_asset - expected_liquidity_removed
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve - expected_a_removed
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount - expected_a_removed
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve - expected_b_removed
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount - expected_b_removed
         );
         assert_eq!(
             final_pool_info.liquidity,
@@ -72,39 +74,45 @@ mod success {
 
     #[tokio::test]
     async fn removes_all_liquidity_passing_exact_a_but_not_exact_b_values() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let liquidity_to_remove = amounts.liquidity;
-        let a_to_remove = amounts.amount_a;
-        let b_to_remove = amounts.amount_b / 2;
-        let expected_liquidity_removed = amounts.liquidity;
-        let expected_a_removed = amounts.amount_a;
-        let expected_b_removed = amounts.amount_b;
+        let liquidity_to_remove = liquidity_parameters.liquidity;
+        let a_to_remove = liquidity_parameters.amounts.0;
+        let b_to_remove = liquidity_parameters.amounts.1 / 2;
+        let expected_liquidity_removed = liquidity_parameters.liquidity;
+        let expected_a_removed = liquidity_parameters.amounts.0;
+        let expected_b_removed = liquidity_parameters.amounts.1;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let remove_liquidity_info = remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(liquidity_to_remove),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
+            exchange.id,
+            liquidity_to_remove,
             a_to_remove,
             b_to_remove,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
-        assert_eq!(remove_liquidity_info.asset_a_amount, expected_a_removed);
-        assert_eq!(remove_liquidity_info.asset_b_amount, expected_b_removed);
-        assert_eq!(remove_liquidity_info.liquidity, expected_liquidity_removed);
+        assert_eq!(
+            remove_liquidity_info.removed_amounts.a.amount,
+            expected_a_removed
+        );
+        assert_eq!(
+            remove_liquidity_info.removed_amounts.b.amount,
+            expected_b_removed
+        );
+        assert_eq!(
+            remove_liquidity_info.burned_liquidity.amount,
+            expected_liquidity_removed
+        );
         assert_eq!(
             final_wallet_balances.asset_a,
             initial_wallet_balances.asset_a + expected_a_removed
@@ -118,12 +126,12 @@ mod success {
             initial_wallet_balances.liquidity_pool_asset - expected_liquidity_removed
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve - expected_a_removed
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount - expected_a_removed
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve - expected_b_removed
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount - expected_b_removed
         );
         assert_eq!(
             final_pool_info.liquidity,
@@ -133,39 +141,45 @@ mod success {
 
     #[tokio::test]
     async fn removes_all_liquidity_passing_exact_b_but_not_exact_a_values() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let liquidity_to_remove = amounts.liquidity;
-        let a_to_remove = amounts.amount_a / 2;
-        let b_to_remove = amounts.amount_b;
-        let expected_liquidity_removed = amounts.liquidity;
-        let expected_a_removed = amounts.amount_a;
-        let expected_b_removed = amounts.amount_b;
+        let liquidity_to_remove = liquidity_parameters.liquidity;
+        let a_to_remove = liquidity_parameters.amounts.0 / 2;
+        let b_to_remove = liquidity_parameters.amounts.1;
+        let expected_liquidity_removed = liquidity_parameters.liquidity;
+        let expected_a_removed = liquidity_parameters.amounts.0;
+        let expected_b_removed = liquidity_parameters.amounts.1;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let remove_liquidity_info = remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(liquidity_to_remove),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
+            exchange.id,
+            liquidity_to_remove,
             a_to_remove,
             b_to_remove,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
-        assert_eq!(remove_liquidity_info.asset_a_amount, expected_a_removed);
-        assert_eq!(remove_liquidity_info.asset_b_amount, expected_b_removed);
-        assert_eq!(remove_liquidity_info.liquidity, expected_liquidity_removed);
+        assert_eq!(
+            remove_liquidity_info.removed_amounts.a.amount,
+            expected_a_removed
+        );
+        assert_eq!(
+            remove_liquidity_info.removed_amounts.b.amount,
+            expected_b_removed
+        );
+        assert_eq!(
+            remove_liquidity_info.burned_liquidity.amount,
+            expected_liquidity_removed
+        );
         assert_eq!(
             final_wallet_balances.asset_a,
             initial_wallet_balances.asset_a + expected_a_removed
@@ -179,12 +193,12 @@ mod success {
             initial_wallet_balances.liquidity_pool_asset - expected_liquidity_removed
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve - expected_a_removed
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount - expected_a_removed
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve - expected_b_removed
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount - expected_b_removed
         );
         assert_eq!(
             final_pool_info.liquidity,
@@ -194,39 +208,45 @@ mod success {
 
     #[tokio::test]
     async fn removes_partial_liquidity() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
-        let liquidity_to_remove = amounts.liquidity / 2;
-        let a_to_remove = amounts.amount_a / 2;
-        let b_to_remove = amounts.amount_b / 2;
-        let expected_liquidity_removed = amounts.liquidity / 2;
-        let expected_a_removed = amounts.amount_a / 2;
-        let expected_b_removed = amounts.amount_b / 2;
+        let liquidity_to_remove = liquidity_parameters.liquidity / 2;
+        let a_to_remove = liquidity_parameters.amounts.0 / 2;
+        let b_to_remove = liquidity_parameters.amounts.1 / 2;
+        let expected_liquidity_removed = liquidity_parameters.liquidity / 2;
+        let expected_a_removed = liquidity_parameters.amounts.0 / 2;
+        let expected_b_removed = liquidity_parameters.amounts.1 / 2;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let remove_liquidity_info = remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(liquidity_to_remove),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
+            exchange.id,
+            liquidity_to_remove,
             a_to_remove,
             b_to_remove,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
-        assert_eq!(remove_liquidity_info.asset_a_amount, expected_a_removed);
-        assert_eq!(remove_liquidity_info.asset_b_amount, expected_b_removed);
-        assert_eq!(remove_liquidity_info.liquidity, expected_liquidity_removed);
+        assert_eq!(
+            remove_liquidity_info.removed_amounts.a.amount,
+            expected_a_removed
+        );
+        assert_eq!(
+            remove_liquidity_info.removed_amounts.b.amount,
+            expected_b_removed
+        );
+        assert_eq!(
+            remove_liquidity_info.burned_liquidity.amount,
+            expected_liquidity_removed
+        );
         assert_eq!(
             final_wallet_balances.asset_a,
             initial_wallet_balances.asset_a + expected_a_removed
@@ -240,12 +260,12 @@ mod success {
             initial_wallet_balances.liquidity_pool_asset - expected_liquidity_removed
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve - expected_a_removed
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount - expected_a_removed
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve - expected_b_removed
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount - expected_b_removed
         );
         assert_eq!(
             final_pool_info.liquidity,
@@ -256,31 +276,46 @@ mod success {
 
 mod revert {
     use super::*;
+    use crate::utils::setup;
+    use fuels::prelude::ContractId;
 
     #[tokio::test]
-    #[should_panic(expected = "NotInitialized")]
-    async fn when_unitialized() {
+    #[should_panic(expected = "AssetPairNotSet")]
+    async fn when_uninitialized() {
         // call setup instead of setup_and_initialize
-        let (exchange_instance, _wallet, _pool_asset_id, _asset_a_id, _asset_b_id, _asset_c_id) =
-            setup().await;
+        let (exchange_instance, _wallet, assets, deadline) = setup().await;
         let a_to_remove = 1;
         let b_to_remove = 1;
-        let deadline = 1000;
 
         remove_liquidity(
             &exchange_instance,
-            CallParameters::new(
-                Some(1),
-                // Sending `None` instead of `Some(AssetId::new(*pool_asset_id))`
-                // because liquidity pool asset does not exist yet.
-                // Normally, this also causes Revert(18446744073709486080),
-                // but this test condition (not initialized contract) reverts before that.
-                None,
-                None,
-            ),
+            ContractId::new(*assets.asset_3), // passing another asset since liquidity pool asset does not exist yet
+            1,
             a_to_remove,
             b_to_remove,
             deadline,
+            false,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "NoLiquidityToRemove")]
+    async fn when_liquidity_is_zero() {
+        // not adding liquidity to contract before attempting to remove
+        let (exchange, _wallet, liquidity_parameters, asset_c_id) =
+            setup_and_construct(true, false).await;
+        let a_to_remove = 1;
+        let b_to_remove = 1;
+
+        remove_liquidity(
+            &exchange.instance,
+            ContractId::new(*asset_c_id), // passing another asset since liquidity does not exist yet
+            1,
+            a_to_remove,
+            b_to_remove,
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
@@ -288,143 +323,102 @@ mod revert {
     #[tokio::test]
     #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_not_liquidity_pool_asset_id() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let a_to_remove = 1;
         let b_to_remove = 1;
 
         remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(amounts.liquidity),
-                // sending an asset other than pool asset
-                Some(exchange.asset_a),
-                None,
-            ),
+            ContractId::new(*exchange.pair.0), // forwarding an asset other than pool asset
+            liquidity_parameters.liquidity,
             a_to_remove,
             b_to_remove,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "AmountCannotBeZero")]
+    #[should_panic(expected = "ExpectedNonZeroParameter")]
     async fn when_minimum_a_amount_is_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let b_to_remove = 1;
 
         remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(amounts.liquidity),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
-            // passing 0 as min_asset_a
-            0,
+            exchange.id,
+            liquidity_parameters.liquidity,
+            0, // passing 0 as min_asset_a
             b_to_remove,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "AmountCannotBeZero")]
+    #[should_panic(expected = "ExpectedNonZeroParameter")]
     async fn when_minimum_b_amount_is_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let a_to_remove = 1;
 
         remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(amounts.liquidity),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
+            exchange.id,
+            liquidity_parameters.liquidity,
             a_to_remove,
-            // passing 0 as min_asset_b
-            0,
-            amounts.deadline,
+            0, // passing 0 as min_asset_b
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "DeadlinePassed")]
-    async fn when_deadline_has_passed() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+    async fn when_deadline_passed() {
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let a_to_remove = 1;
         let b_to_remove = 1;
 
         remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(amounts.liquidity),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
+            exchange.id,
+            liquidity_parameters.liquidity,
             a_to_remove,
             b_to_remove,
-            // passing 0 as deadline
-            0,
+            0, // passing 0 as deadline
+            false,
         )
         .await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "AmountCannotBeZero")]
+    #[should_panic(expected = "ExpectedNonZeroAmount")]
     async fn when_msg_amount_is_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let a_to_remove = 1;
         let b_to_remove = 1;
 
         remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                // sending 0 msg_amount
-                Some(0),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
+            exchange.id,
+            0, // forwarding 0 as msg_amount
             a_to_remove,
             b_to_remove,
-            amounts.deadline,
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "LiquidityCannotBeZero")]
-    async fn when_liquidity_is_zero() {
-        // not adding liquidity to contract before attempting to remove
-        let (exchange, _wallet, amounts, _asset_c_id) = setup_and_initialize().await;
-        let a_to_remove = 1;
-        let b_to_remove = 1;
-
-        remove_liquidity(
-            &exchange.instance,
-            CallParameters::new(
-                Some(1),
-                // Sending `None` instead of `Some(exchange.liquidity_pool_asset)`
-                // because liquidity pool asset does not exist yet.
-                // Normally, this also causes Revert(18446744073709486080),
-                // but this test condition (zero liquidity) reverts before that.
-                None,
-                None,
-            ),
-            a_to_remove,
-            b_to_remove,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
@@ -432,27 +426,25 @@ mod revert {
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_a_reserve_is_insufficient() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let b_to_remove = 1;
 
-        let pool_info = pool_info(&exchange.instance).await.value;
-        let asset_a_reserve = pool_info.asset_a_reserve;
+        let pool_info = pool_info(&exchange.instance).await;
+        let asset_a_reserve = pool_info.reserves.a.amount;
         let liquidity = pool_info.liquidity;
-        let asset_a_amount_to_remove = (amounts.liquidity * asset_a_reserve) / liquidity;
+        let asset_a_amount_to_remove =
+            (liquidity_parameters.liquidity * asset_a_reserve) / liquidity;
 
         remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(amounts.liquidity),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
-            // setting min_asset_a to be higher than what can be removed
-            asset_a_amount_to_remove + 10,
+            exchange.id,
+            liquidity_parameters.liquidity,
+            asset_a_amount_to_remove + 10, // setting min_asset_a to be higher than what can be removed
             b_to_remove,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
         .await;
     }
@@ -460,27 +452,25 @@ mod revert {
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_b_reserve_is_insufficient() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let a_to_remove = 1;
 
-        let pool_info = pool_info(&exchange.instance).await.value;
-        let asset_b_reserve = pool_info.asset_b_reserve;
+        let pool_info = pool_info(&exchange.instance).await;
+        let asset_b_reserve = pool_info.reserves.b.amount;
         let liquidity = pool_info.liquidity;
-        let asset_b_amount_to_remove = (amounts.liquidity * asset_b_reserve) / liquidity;
+        let asset_b_amount_to_remove =
+            (liquidity_parameters.liquidity * asset_b_reserve) / liquidity;
 
         remove_liquidity(
             &exchange.instance,
-            CallParameters::new(
-                Some(amounts.liquidity),
-                Some(exchange.liquidity_pool_asset),
-                None,
-            ),
+            exchange.id,
+            liquidity_parameters.liquidity,
             a_to_remove,
-            // setting min_asset_b to be higher than what can be removed
-            asset_b_amount_to_remove + 10,
-            amounts.deadline,
+            asset_b_amount_to_remove + 10, // setting min_asset_b to be higher than what can be removed
+            liquidity_parameters.deadline,
+            true,
         )
         .await;
     }

--- a/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_input.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_input.rs
@@ -1,38 +1,38 @@
-use crate::utils::{
-    abi_calls::{pool_info, preview_swap_exact_input, swap_exact_input},
-    test_helpers::{setup, setup_initialize_deposit_and_add_liquidity, wallet_balances},
-};
-use fuels::prelude::*;
+use crate::utils::setup_and_construct;
+use test_utils::interface::exchange::{preview_swap_exact_input, swap_exact_input};
 
 mod success {
     use super::*;
+    use crate::utils::wallet_balances;
+    use test_utils::interface::exchange::pool_info;
 
     #[tokio::test]
     async fn swaps_a_for_b() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let input_amount = 10;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let min_output =
-            preview_swap_exact_input(&exchange.instance, input_amount, exchange.asset_a)
+            preview_swap_exact_input(&exchange.instance, input_amount, exchange.pair.0, true)
                 .await
-                .value
+                .other_asset
                 .amount;
 
         let output_amount = swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(input_amount), Some(exchange.asset_a), None),
+            exchange.pair.0,
+            input_amount,
             Some(min_output),
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         assert_eq!(output_amount >= min_output, true);
@@ -45,41 +45,42 @@ mod success {
             initial_wallet_balances.asset_b + output_amount
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve + input_amount
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount + input_amount
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve - output_amount
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount - output_amount
         );
     }
 
     #[tokio::test]
     async fn swaps_b_for_a() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let input_amount = 10;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let min_output =
-            preview_swap_exact_input(&exchange.instance, input_amount, exchange.asset_b)
+            preview_swap_exact_input(&exchange.instance, input_amount, exchange.pair.1, true)
                 .await
-                .value
+                .other_asset
                 .amount;
 
         let output_amount = swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(input_amount), Some(exchange.asset_b), None),
+            exchange.pair.1,
+            input_amount,
             Some(min_output),
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         assert_eq!(output_amount >= min_output, true);
@@ -92,35 +93,36 @@ mod success {
             initial_wallet_balances.asset_a + output_amount
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve + input_amount
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount + input_amount
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve - output_amount
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount - output_amount
         );
     }
 
     #[tokio::test]
     async fn swaps_without_specifying_min_output() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let input_amount = 10;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let output_amount = swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(input_amount), Some(exchange.asset_a), None),
+            exchange.pair.0,
+            input_amount,
             None,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         assert_eq!(
@@ -132,49 +134,42 @@ mod success {
             initial_wallet_balances.asset_b + output_amount
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve + input_amount
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount + input_amount
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve - output_amount
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount - output_amount
         );
     }
 }
 
 mod revert {
     use super::*;
+    use crate::utils::setup;
 
     #[tokio::test]
-    #[should_panic(expected = "NotInitialized")]
-    async fn when_unitialized() {
+    #[should_panic(expected = "AssetPairNotSet")]
+    async fn when_uninitialized() {
         // call setup instead of setup_and_initialize
-        let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
-            setup().await;
+        let (exchange_instance, _wallet, assets, deadline) = setup().await;
 
-        let deadline = 1000;
-
-        swap_exact_input(
-            &exchange_instance,
-            CallParameters::new(Some(1), Some(AssetId::new(*asset_a_id)), None),
-            None,
-            deadline,
-        )
-        .await;
+        swap_exact_input(&exchange_instance, assets.asset_1, 1, None, deadline, false).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
-        let (exchange, _wallet, amounts, asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, asset_c_id) =
+            setup_and_construct(true, true).await;
 
         swap_exact_input(
             &exchange.instance,
-            // sending invalid asset
-            CallParameters::new(Some(1), Some(AssetId::new(*asset_c_id)), None),
+            asset_c_id,
+            1,
             None,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
@@ -182,31 +177,33 @@ mod revert {
     #[tokio::test]
     #[should_panic(expected = "DeadlinePassed")]
     async fn when_deadline_has_passed() {
-        let (exchange, _wallet, _amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, _liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(1), Some(exchange.asset_a), None),
+            exchange.pair.0,
+            1,
             None,
-            // passing 0 deadline
-            0,
+            0, // passing 0 deadline
+            false,
         )
         .await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "AmountCannotBeZero")]
+    #[should_panic(expected = "ExpectedNonZeroAmount")]
     async fn when_msg_amount_is_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         swap_exact_input(
             &exchange.instance,
-            // forwarding 0 as msg_amount
-            CallParameters::new(Some(0), Some(exchange.asset_a), None),
+            exchange.pair.0,
+            0, // forwarding 0 as msg_amount
             None,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
@@ -214,23 +211,24 @@ mod revert {
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_minimum_a_constraint_is_too_high() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let input_amount = 10;
 
         let preview_amount =
-            preview_swap_exact_input(&exchange.instance, input_amount, exchange.asset_a)
+            preview_swap_exact_input(&exchange.instance, input_amount, exchange.pair.0, true)
                 .await
-                .value
+                .other_asset
                 .amount;
 
         swap_exact_input(
             &exchange.instance,
-            CallParameters::new(Some(input_amount), Some(exchange.asset_a), None),
-            // setting min too high
-            Some(preview_amount + 1),
-            amounts.deadline,
+            exchange.pair.0,
+            input_amount,
+            Some(preview_amount + 1), // setting min too high
+            liquidity_parameters.deadline,
+            true,
         )
         .await;
     }

--- a/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_output.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/swap_exact_output.rs
@@ -1,38 +1,38 @@
-use crate::utils::{
-    abi_calls::{pool_info, preview_swap_exact_output, swap_exact_output},
-    test_helpers::{setup, setup_initialize_deposit_and_add_liquidity, wallet_balances},
-};
-use fuels::prelude::*;
+use crate::utils::setup_and_construct;
+use test_utils::interface::exchange::{preview_swap_exact_output, swap_exact_output};
 
 mod success {
     use super::*;
+    use crate::utils::wallet_balances;
+    use test_utils::interface::exchange::pool_info;
 
     #[tokio::test]
     async fn swaps_a_for_b_without_refund() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let max_input =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_b)
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.1, true)
                 .await
-                .value
+                .other_asset
                 .amount;
 
         let input_amount = swap_exact_output(
             &exchange.instance,
-            CallParameters::new(Some(max_input), Some(exchange.asset_a), Some(10_000_000)),
+            exchange.pair.0,
+            max_input,
             output_amount,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         assert_eq!(input_amount <= max_input, true);
@@ -45,47 +45,44 @@ mod success {
             initial_wallet_balances.asset_b + output_amount
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve + input_amount
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount + input_amount
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve - output_amount
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount - output_amount
         );
     }
 
     #[tokio::test]
     async fn swaps_a_for_b_with_refund() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
         let forward_extra = 100;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let max_input =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_b)
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.1, true)
                 .await
-                .value
+                .other_asset
                 .amount;
         let forward_amount = max_input + forward_extra;
 
         let input_amount = swap_exact_output(
             &exchange.instance,
-            CallParameters::new(
-                Some(forward_amount),
-                Some(exchange.asset_a),
-                Some(10_000_000),
-            ),
+            exchange.pair.0,
+            forward_amount,
             output_amount,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         assert_eq!(input_amount <= max_input, true);
@@ -98,41 +95,42 @@ mod success {
             initial_wallet_balances.asset_b + output_amount
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve + input_amount
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount + input_amount
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve - output_amount
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount - output_amount
         );
     }
 
     #[tokio::test]
     async fn swaps_b_for_a_without_refund() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let max_input =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_a)
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.0, true)
                 .await
-                .value
+                .other_asset
                 .amount;
 
         let input_amount = swap_exact_output(
             &exchange.instance,
-            CallParameters::new(Some(max_input), Some(exchange.asset_b), Some(10_000_000)),
+            exchange.pair.1,
+            max_input,
             output_amount,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         assert_eq!(input_amount <= max_input, true);
@@ -145,47 +143,44 @@ mod success {
             initial_wallet_balances.asset_a + output_amount
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve + input_amount
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount + input_amount
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve - output_amount
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount - output_amount
         );
     }
 
     #[tokio::test]
     async fn swaps_b_for_a_with_refund() {
-        let (exchange, wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
         let forward_extra = 100;
 
-        let initial_pool_info = pool_info(&exchange.instance).await.value;
+        let initial_pool_info = pool_info(&exchange.instance).await;
         let initial_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         let max_input =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_a)
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.0, true)
                 .await
-                .value
+                .other_asset
                 .amount;
         let forward_amount = max_input + forward_extra;
 
         let input_amount = swap_exact_output(
             &exchange.instance,
-            CallParameters::new(
-                Some(forward_amount),
-                Some(exchange.asset_b),
-                Some(10_000_000),
-            ),
+            exchange.pair.1,
+            forward_amount,
             output_amount,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
-        .await
-        .value;
+        .await;
 
-        let final_pool_info = pool_info(&exchange.instance).await.value;
+        let final_pool_info = pool_info(&exchange.instance).await;
         let final_wallet_balances = wallet_balances(&exchange, &wallet).await;
 
         assert_eq!(input_amount <= max_input, true);
@@ -198,33 +193,34 @@ mod success {
             initial_wallet_balances.asset_a + output_amount
         );
         assert_eq!(
-            final_pool_info.asset_b_reserve,
-            initial_pool_info.asset_b_reserve + input_amount
+            final_pool_info.reserves.b.amount,
+            initial_pool_info.reserves.b.amount + input_amount
         );
         assert_eq!(
-            final_pool_info.asset_a_reserve,
-            initial_pool_info.asset_a_reserve - output_amount
+            final_pool_info.reserves.a.amount,
+            initial_pool_info.reserves.a.amount - output_amount
         );
     }
 }
 
 mod revert {
     use super::*;
+    use crate::utils::setup;
 
     #[tokio::test]
-    #[should_panic(expected = "NotInitialized")]
-    async fn when_unitialized() {
+    #[should_panic(expected = "AssetPairNotSet")]
+    async fn when_uninitialized() {
         // call setup instead of setup_and_initialize
-        let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
-            setup().await;
+        let (exchange_instance, _wallet, assets, deadline) = setup().await;
         let output_amount = 10;
-        let deadline = 1000;
 
         swap_exact_output(
             &exchange_instance,
-            CallParameters::new(Some(1), Some(AssetId::new(*asset_a_id)), Some(10_000_000)),
+            assets.asset_1,
+            1,
             output_amount,
             deadline,
+            false,
         )
         .await;
     }
@@ -232,127 +228,154 @@ mod revert {
     #[tokio::test]
     #[should_panic(expected = "InvalidAsset")]
     async fn when_msg_asset_id_is_invalid() {
-        let (exchange, _wallet, amounts, asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
         swap_exact_output(
             &exchange.instance,
-            // sending invalid asset
-            CallParameters::new(Some(1), Some(AssetId::new(*asset_c_id)), Some(10_000_000)),
+            asset_c_id, // forwarding invalid asset
+            1,
             output_amount,
-            amounts.deadline,
-        )
-        .await;
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "AmountCannotBeZero")]
-    async fn when_output_amount_is_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
-
-        swap_exact_output(
-            &exchange.instance,
-            CallParameters::new(Some(1), Some(exchange.asset_a), Some(10_000_000)),
-            // passing 0 amount
-            0,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "DeadlinePassed")]
-    async fn when_deadline_has_passed() {
-        let (exchange, _wallet, _amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+    async fn when_deadline_passed() {
+        let (exchange, _wallet, _liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
         swap_exact_output(
             &exchange.instance,
-            CallParameters::new(Some(1), Some(exchange.asset_a), Some(10_000_000)),
+            exchange.pair.0,
+            1,
             output_amount,
-            // passing 0 deadline
-            0,
+            0, // passing 0 deadline
+            false,
         )
         .await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "AmountCannotBeZero")]
+    #[should_panic(expected = "ExpectedNonZeroParameter")]
+    async fn when_output_amount_is_zero() {
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
+
+        swap_exact_output(
+            &exchange.instance,
+            exchange.pair.0,
+            1,
+            0, // passing 0 amount
+            liquidity_parameters.deadline,
+            false,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "ExpectedNonZeroAmount")]
     async fn when_msg_amount_is_zero() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
         swap_exact_output(
             &exchange.instance,
-            // forwarding 0 as msg_amount
-            CallParameters::new(Some(0), Some(exchange.asset_a), Some(10_000_000)),
+            exchange.pair.0,
+            0, // forwarding 0 as msg_amount
             output_amount,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            false,
         )
         .await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "ProvidedAmountTooLow")]
+    #[should_panic(expected = "InsufficientReserve")]
+    async fn when_output_amount_is_more_than_reserve() {
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
+
+        let output_amount = 10;
+        let forward_amount =
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.0, true)
+                .await
+                .other_asset
+                .amount;
+
+        swap_exact_output(
+            &exchange.instance,
+            exchange.pair.0,
+            forward_amount,
+            // requesting an output amount that is more than what the contract has in its reserves
+            liquidity_parameters.amounts.0 + 1000000,
+            liquidity_parameters.deadline,
+            false,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_forwarding_insufficient_amount_of_a() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
         let preview_amount =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_b)
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.1, true)
                 .await
-                .value
+                .other_asset
                 .amount;
+
         // forwarding insufficient amount
         let forward_amount = preview_amount - 1;
 
         swap_exact_output(
             &exchange.instance,
-            CallParameters::new(
-                Some(forward_amount),
-                Some(exchange.asset_a),
-                Some(10_000_000),
-            ),
+            exchange.pair.0,
+            forward_amount,
             output_amount,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
         .await;
     }
 
     #[tokio::test]
-    #[should_panic(expected = "ProvidedAmountTooLow")]
+    #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn when_forwarding_insufficient_amount_of_b() {
-        let (exchange, _wallet, amounts, _asset_c_id, _added_liquidity) =
-            setup_initialize_deposit_and_add_liquidity().await;
+        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
+            setup_and_construct(true, true).await;
 
         let output_amount = 10;
 
         let preview_amount =
-            preview_swap_exact_output(&exchange.instance, output_amount, exchange.asset_a)
+            preview_swap_exact_output(&exchange.instance, output_amount, exchange.pair.0, true)
                 .await
-                .value
+                .other_asset
                 .amount;
+
         // forwarding insufficient amount
         let forward_amount = preview_amount - 1;
 
         swap_exact_output(
             &exchange.instance,
-            CallParameters::new(
-                Some(forward_amount),
-                Some(exchange.asset_b),
-                Some(10_000_000),
-            ),
+            exchange.pair.1,
+            forward_amount,
             output_amount,
-            amounts.deadline,
+            liquidity_parameters.deadline,
+            true,
         )
         .await;
     }

--- a/AMM/project/contracts/exchange-contract/tests/functions/withdraw.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/withdraw.rs
@@ -1,31 +1,26 @@
-use crate::utils::{
-    abi_calls::{balance, deposit, withdraw},
-    test_helpers::{setup, setup_and_initialize},
-};
-use fuels::prelude::*;
+use crate::utils::setup_and_construct;
+use test_utils::interface::exchange::{deposit, withdraw};
 
 mod success {
     use super::*;
+    use test_utils::interface::exchange::balance;
 
     #[tokio::test]
     async fn withdraws_entire_deposit_of_asset_a() {
-        let (exchange, wallet, _amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, wallet, _liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
         let deposit_amount = 100;
         let withdraw_amount = deposit_amount;
 
-        deposit(
-            &exchange.instance,
-            CallParameters::new(Some(deposit_amount), Some(exchange.asset_a), None),
-        )
-        .await;
+        deposit(&exchange.instance, deposit_amount, exchange.pair.0).await;
 
-        let initial_contract_balance = balance(&exchange.instance, exchange.asset_a).await.value;
-        let initial_wallet_balance = wallet.get_asset_balance(&exchange.asset_a).await.unwrap();
+        let initial_contract_balance = balance(&exchange.instance, exchange.pair.0).await;
+        let initial_wallet_balance = wallet.get_asset_balance(&exchange.pair.0).await.unwrap();
 
-        withdraw(&exchange.instance, deposit_amount, exchange.asset_a).await;
+        withdraw(&exchange.instance, deposit_amount, exchange.pair.0).await;
 
-        let final_contract_balance = balance(&exchange.instance, exchange.asset_a).await.value;
-        let final_wallet_balance = wallet.get_asset_balance(&exchange.asset_a).await.unwrap();
+        let final_contract_balance = balance(&exchange.instance, exchange.pair.0).await;
+        let final_wallet_balance = wallet.get_asset_balance(&exchange.pair.0).await.unwrap();
 
         assert_eq!(
             final_contract_balance,
@@ -39,23 +34,20 @@ mod success {
 
     #[tokio::test]
     async fn withdraws_asset_a_partially() {
-        let (exchange, wallet, _amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, wallet, _liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
         let deposit_amount = 100;
         let withdraw_amount = 50;
 
-        deposit(
-            &exchange.instance,
-            CallParameters::new(Some(deposit_amount), Some(exchange.asset_a), None),
-        )
-        .await;
+        deposit(&exchange.instance, deposit_amount, exchange.pair.0).await;
 
-        let initial_contract_balance = balance(&exchange.instance, exchange.asset_a).await.value;
-        let initial_wallet_balance = wallet.get_asset_balance(&exchange.asset_a).await.unwrap();
+        let initial_contract_balance = balance(&exchange.instance, exchange.pair.0).await;
+        let initial_wallet_balance = wallet.get_asset_balance(&exchange.pair.0).await.unwrap();
 
-        withdraw(&exchange.instance, withdraw_amount, exchange.asset_a).await;
+        withdraw(&exchange.instance, withdraw_amount, exchange.pair.0).await;
 
-        let final_contract_balance = balance(&exchange.instance, exchange.asset_a).await.value;
-        let final_wallet_balance = wallet.get_asset_balance(&exchange.asset_a).await.unwrap();
+        let final_contract_balance = balance(&exchange.instance, exchange.pair.0).await;
+        let final_wallet_balance = wallet.get_asset_balance(&exchange.pair.0).await.unwrap();
 
         assert_eq!(
             final_contract_balance,
@@ -70,46 +62,40 @@ mod success {
 
 mod revert {
     use super::*;
+    use crate::utils::setup;
 
     #[tokio::test]
-    #[should_panic(expected = "NotInitialized")]
+    #[should_panic(expected = "AssetPairNotSet")]
     async fn on_unitialized() {
-        // call setup instead of setup_and_initialize
-        let (exchange_instance, _wallet, _pool_asset_id, asset_a_id, _asset_b_id, _asset_c_id) =
-            setup().await;
+        // call setup instead of setup_and_construct
+        let (exchange_instance, _wallet, assets, _deadline) = setup().await;
 
-        withdraw(&exchange_instance, 0, asset_a_id).await;
+        withdraw(&exchange_instance, 0, assets.asset_1).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "InvalidAsset")]
     async fn on_invalid_asset() {
-        let (exchange, _wallet, _amounts, asset_c_id) = setup_and_initialize().await;
+        let (exchange, _wallet, _liquidity_parameters, asset_c_id) =
+            setup_and_construct(false, false).await;
         let deposit_amount = 100;
 
-        deposit(
-            &exchange.instance,
-            CallParameters::new(Some(deposit_amount), Some(exchange.asset_a), None),
-        )
-        .await;
+        deposit(&exchange.instance, deposit_amount, exchange.pair.0).await;
 
-        // sending invalid asset
+        // passing invalid asset
         withdraw(&exchange.instance, 0, asset_c_id).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "DesiredAmountTooHigh")]
     async fn on_withdraw_more_than_deposited() {
-        let (exchange, _wallet, _amounts, _asset_c_id) = setup_and_initialize().await;
+        let (exchange, _wallet, _liquidity_parameters, _asset_c_id) =
+            setup_and_construct(false, false).await;
         let deposit_amount = 100;
 
-        deposit(
-            &exchange.instance,
-            CallParameters::new(Some(deposit_amount), Some(exchange.asset_a), None),
-        )
-        .await;
+        deposit(&exchange.instance, deposit_amount, exchange.pair.0).await;
 
         // attempting to withdraw more than deposit amount
-        withdraw(&exchange.instance, deposit_amount + 1, exchange.asset_a).await;
+        withdraw(&exchange.instance, deposit_amount + 1, exchange.pair.0).await;
     }
 }

--- a/AMM/project/contracts/exchange-contract/tests/utils/mod.rs
+++ b/AMM/project/contracts/exchange-contract/tests/utils/mod.rs
@@ -1,27 +1,22 @@
-use fuels::{contract::call_response::FuelCallResponse, prelude::*};
-
-abigen!(
-    Exchange,
-    "./project/contracts/exchange-contract/out/debug/exchange-contract-abi.json"
-);
+use fuels::prelude::*;
+use test_utils::{
+    data_structures::{
+        ExchangeContract, ExchangeContractConfiguration, LiquidityParameters,
+        WalletAssetConfiguration,
+    },
+    interface::{
+        exchange::{balance, deposit},
+        Exchange,
+    },
+    setup::common::{
+        deploy_and_construct_exchange, deploy_exchange, deposit_and_add_liquidity,
+        setup_wallet_and_provider,
+    },
+};
 
 pub struct ContractBalances {
     pub asset_a: u64,
     pub asset_b: u64,
-}
-
-pub struct ExchangeContract {
-    pub asset_a: AssetId,
-    pub asset_b: AssetId,
-    pub instance: Exchange,
-    pub liquidity_pool_asset: AssetId,
-}
-
-pub struct LiquidityParameters {
-    pub amount_a: u64,
-    pub amount_b: u64,
-    pub deadline: u64,
-    pub liquidity: u64,
 }
 
 pub struct WalletBalances {
@@ -30,333 +25,99 @@ pub struct WalletBalances {
     pub liquidity_pool_asset: u64,
 }
 
-pub mod paths {
-    pub const EXCHANGE_CONTRACT_BINARY_PATH: &str = "./out/debug/exchange-contract.bin";
+pub struct Assets {
+    pub asset_1: AssetId,
+    pub asset_2: AssetId,
+    pub asset_3: AssetId,
+    pub liquidity_pool_asset: AssetId,
 }
 
-pub mod abi_calls {
-    use super::*;
-
-    pub async fn add_liquidity(
-        contract: &Exchange,
-        call_params: CallParameters,
-        tx_params: TxParameters,
-        desired_liquidity: u64,
-        deadline: u64,
-    ) -> FuelCallResponse<u64> {
-        contract
-            .methods()
-            .add_liquidity(desired_liquidity, deadline)
-            .call_params(call_params)
-            // `add_liquidity` adds liquidity by using up at least one of the assets
-            // one variable output is for the minted liquidity pool asset
-            // the other variable output is for the asset that is not used up
-            .append_variable_outputs(2)
-            .tx_params(tx_params)
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn constructor(
-        contract: &Exchange,
-        pair: (AssetId, AssetId),
-    ) -> FuelCallResponse<()> {
-        contract
-            .methods()
-            .constructor((ContractId::new(*pair.0), ContractId::new(*pair.1)))
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn deposit(contract: &Exchange, call_params: CallParameters) -> FuelCallResponse<()> {
-        contract
-            .methods()
-            .deposit()
-            .call_params(call_params)
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn remove_liquidity(
-        contract: &Exchange,
-        call_params: CallParameters,
-        min_asset_a: u64,
-        min_asset_b: u64,
-        deadline: u64,
-    ) -> FuelCallResponse<RemoveLiquidityInfo> {
-        contract
-            .methods()
-            .remove_liquidity(min_asset_a, min_asset_b, deadline)
-            .call_params(call_params)
-            .tx_params(TxParameters::new(None, Some(10_000_000), None))
-            .append_variable_outputs(2)
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn swap_exact_input(
-        contract: &Exchange,
-        call_params: CallParameters,
-        min_output: Option<u64>,
-        deadline: u64,
-    ) -> FuelCallResponse<u64> {
-        contract
-            .methods()
-            .swap_exact_input(min_output, deadline)
-            .call_params(call_params)
-            .tx_params(TxParameters::new(None, Some(10_000_000), None))
-            .append_variable_outputs(1)
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn swap_exact_output(
-        contract: &Exchange,
-        call_params: CallParameters,
-        output: u64,
-        deadline: u64,
-    ) -> FuelCallResponse<u64> {
-        contract
-            .methods()
-            .swap_exact_output(output, deadline)
-            .call_params(call_params)
-            .tx_params(TxParameters::new(None, Some(10_000_000), None))
-            .append_variable_outputs(2)
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn withdraw(
-        contract: &Exchange,
-        amount: u64,
-        asset: AssetId,
-    ) -> FuelCallResponse<()> {
-        contract
-            .methods()
-            .withdraw(amount, ContractId::new(*asset))
-            .append_variable_outputs(1)
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn balance(contract: &Exchange, asset: AssetId) -> FuelCallResponse<u64> {
-        contract
-            .methods()
-            .balance(ContractId::new(*asset))
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn pool_info(contract: &Exchange) -> FuelCallResponse<PoolInfo> {
-        contract.methods().pool_info().call().await.unwrap()
-    }
-
-    pub async fn preview_add_liquidity(
-        contract: &Exchange,
-        call_params: CallParameters,
-        tx_params: TxParameters,
-        amount: u64,
-        asset: AssetId,
-    ) -> FuelCallResponse<PreviewAddLiquidityInfo> {
-        contract
-            .methods()
-            .preview_add_liquidity(amount, ContractId::new(*asset))
-            .call_params(call_params)
-            .tx_params(tx_params)
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn preview_swap_exact_input(
-        contract: &Exchange,
-        exact_input: u64,
-        input_asset: AssetId,
-    ) -> FuelCallResponse<PreviewSwapInfo> {
-        contract
-            .methods()
-            .preview_swap_exact_input(exact_input, ContractId::new(*input_asset))
-            .tx_params(TxParameters::new(None, Some(10_000_000), None))
-            .call()
-            .await
-            .unwrap()
-    }
-
-    pub async fn preview_swap_exact_output(
-        contract: &Exchange,
-        exact_output: u64,
-        output_asset: AssetId,
-    ) -> FuelCallResponse<PreviewSwapInfo> {
-        contract
-            .methods()
-            .preview_swap_exact_output(exact_output, ContractId::new(*output_asset))
-            .tx_params(TxParameters::new(None, Some(10_000_000), None))
-            .call()
-            .await
-            .unwrap()
-    }
+pub async fn contract_balances(exchange: &ExchangeContract) -> ContractBalances {
+    let asset_a = balance(&exchange.instance, exchange.pair.0).await;
+    let asset_b = balance(&exchange.instance, exchange.pair.1).await;
+    ContractBalances { asset_a, asset_b }
 }
 
-pub mod test_helpers {
-    use super::*;
-    use abi_calls::{add_liquidity, balance, constructor, deposit};
-    use paths::EXCHANGE_CONTRACT_BINARY_PATH;
-
-    pub async fn contract_balances(exchange: &ExchangeContract) -> ContractBalances {
-        let asset_a = balance(&exchange.instance, exchange.asset_a).await.value;
-        let asset_b = balance(&exchange.instance, exchange.asset_b).await.value;
-        ContractBalances { asset_a, asset_b }
-    }
-
-    pub async fn wallet_balances(
-        exchange: &ExchangeContract,
-        wallet: &WalletUnlocked,
-    ) -> WalletBalances {
-        let asset_a = wallet.get_asset_balance(&exchange.asset_a).await.unwrap();
-        let asset_b = wallet.get_asset_balance(&exchange.asset_b).await.unwrap();
-        let liquidity_pool_asset = wallet
-            .get_asset_balance(&exchange.liquidity_pool_asset)
-            .await
-            .unwrap();
-        WalletBalances {
-            asset_a,
-            asset_b,
-            liquidity_pool_asset,
-        }
-    }
-
-    pub async fn deposit_but_do_not_add_liquidity(
-        amounts: &LiquidityParameters,
-        exchange: &ExchangeContract,
-    ) {
-        deposit(
-            &exchange.instance,
-            CallParameters::new(Some(amounts.amount_a), Some(exchange.asset_a), None),
-        )
-        .await;
-
-        deposit(
-            &exchange.instance,
-            CallParameters::new(Some(amounts.amount_b), Some(exchange.asset_b), None),
-        )
-        .await;
-    }
-
-    pub async fn deposit_and_add_liquidity(
-        amounts: &LiquidityParameters,
-        exchange: &ExchangeContract,
-    ) -> u64 {
-        deposit_but_do_not_add_liquidity(&amounts, &exchange).await;
-
-        let added = add_liquidity(
-            &exchange.instance,
-            CallParameters::new(Some(0), None, None),
-            TxParameters::new(None, Some(100_000_000), None),
-            amounts.liquidity,
-            amounts.deadline,
-        )
-        .await;
-
-        added.value
-    }
-
-    pub async fn setup() -> (Exchange, WalletUnlocked, AssetId, AssetId, AssetId, AssetId) {
-        // setup wallet and provider
-        let mut wallet = WalletUnlocked::new_random(None);
-        let num_assets = 3;
-        let coins_per_asset = 10;
-        let amount_per_coin = 1_000_000;
-        let (coins, asset_ids) = setup_multiple_assets_coins(
-            wallet.address(),
-            num_assets,
-            coins_per_asset,
-            amount_per_coin,
-        );
-        let (provider, _socket_addr) = setup_test_provider(coins.clone(), vec![], None, None).await;
-        wallet.set_provider(provider);
-
-        // setup exchange contract
-        let exchange_contract_id = Contract::deploy(
-            EXCHANGE_CONTRACT_BINARY_PATH,
-            &wallet,
-            TxParameters::default(),
-            StorageConfiguration::default(),
-        )
+pub async fn wallet_balances(
+    exchange: &ExchangeContract,
+    wallet: &WalletUnlocked,
+) -> WalletBalances {
+    let asset_a = wallet.get_asset_balance(&exchange.pair.0).await.unwrap();
+    let asset_b = wallet.get_asset_balance(&exchange.pair.1).await.unwrap();
+    let liquidity_pool_asset = wallet
+        .get_asset_balance(&AssetId::new(*exchange.id))
         .await
         .unwrap();
-        let exchange_instance = Exchange::new(exchange_contract_id.clone(), wallet.clone());
+    WalletBalances {
+        asset_a,
+        asset_b,
+        liquidity_pool_asset,
+    }
+}
 
-        let liquidity_pool_asset_id = AssetId::from(*exchange_contract_id.hash());
+pub async fn setup() -> (Exchange, WalletUnlocked, Assets, u64) {
+    let (wallet, asset_ids, provider) =
+        setup_wallet_and_provider(&WalletAssetConfiguration::default()).await;
 
-        (
-            exchange_instance,
-            wallet,
-            liquidity_pool_asset_id,
-            asset_ids[0],
-            asset_ids[1],
-            asset_ids[2],
+    let (exchange_id, exchange_instance) = deploy_exchange(
+        &wallet,
+        &ExchangeContractConfiguration::new(None, None, None, None),
+    )
+    .await;
+
+    let assets = Assets {
+        asset_1: asset_ids[0],
+        asset_2: asset_ids[1],
+        asset_3: asset_ids[2],
+        liquidity_pool_asset: AssetId::from(*exchange_id),
+    };
+
+    let deadline = provider.latest_block_height().await.unwrap() + 5;
+
+    (exchange_instance, wallet, assets, deadline)
+}
+
+pub async fn setup_and_construct(
+    deposit_both: bool,
+    add_liquidity: bool,
+) -> (
+    ExchangeContract,
+    WalletUnlocked,
+    LiquidityParameters,
+    AssetId,
+) {
+    let (wallet, asset_ids, provider) =
+        setup_wallet_and_provider(&WalletAssetConfiguration::default()).await;
+
+    let exchange = deploy_and_construct_exchange(
+        &wallet,
+        &ExchangeContractConfiguration::new(Some((asset_ids[0], asset_ids[1])), None, None, None),
+    )
+    .await;
+
+    let liquidity_parameters = LiquidityParameters::new(
+        Some((10000, 40000)),
+        Some(provider.latest_block_height().await.unwrap() + 20),
+        Some(20000),
+    );
+
+    if deposit_both && add_liquidity {
+        deposit_and_add_liquidity(&liquidity_parameters, &exchange, false).await;
+    } else if deposit_both {
+        deposit(
+            &exchange.instance,
+            liquidity_parameters.amounts.0,
+            exchange.pair.0,
         )
+        .await;
+
+        deposit(
+            &exchange.instance,
+            liquidity_parameters.amounts.1,
+            exchange.pair.1,
+        )
+        .await;
     }
 
-    pub async fn setup_and_initialize() -> (
-        ExchangeContract,
-        WalletUnlocked,
-        LiquidityParameters,
-        AssetId,
-    ) {
-        let (exchange_instance, wallet, liquidity_pool_asset, asset_a, asset_b, asset_c) =
-            setup().await;
-        constructor(&exchange_instance, (asset_a, asset_b)).await;
-
-        let exchange = ExchangeContract {
-            asset_a,
-            asset_b,
-            instance: exchange_instance,
-            liquidity_pool_asset,
-        };
-
-        let amounts = LiquidityParameters {
-            amount_a: 100,
-            amount_b: 400,
-            deadline: 1000,
-            liquidity: 200,
-        };
-
-        (exchange, wallet, amounts, asset_c)
-    }
-
-    pub async fn setup_initialize_and_deposit_but_do_not_add_liquidity() -> (
-        ExchangeContract,
-        WalletUnlocked,
-        LiquidityParameters,
-        AssetId,
-    ) {
-        let (exchange, wallet, amounts, asset_c) = setup_and_initialize().await;
-
-        deposit_but_do_not_add_liquidity(&amounts, &exchange).await;
-
-        (exchange, wallet, amounts, asset_c)
-    }
-
-    pub async fn setup_initialize_deposit_and_add_liquidity() -> (
-        ExchangeContract,
-        WalletUnlocked,
-        LiquidityParameters,
-        AssetId,
-        u64,
-    ) {
-        let (exchange, wallet, amounts, asset_c) = setup_and_initialize().await;
-
-        let added_liquidity = deposit_and_add_liquidity(&amounts, &exchange).await;
-
-        (exchange, wallet, amounts, asset_c, added_liquidity)
-    }
+    (exchange, wallet, liquidity_parameters, asset_ids[2])
 }

--- a/AMM/project/libraries/src/data_structures.sw
+++ b/AMM/project/libraries/src/data_structures.sw
@@ -1,39 +1,118 @@
 library data_structures;
 
+pub struct Asset {
+    /// Identifier of asset
+    id: ContractId,
+    /// Amount of asset that can represent reserve amount, deposit amount, withdraw amount and more depending on the context
+    amount: u64,
+}
+
+impl Asset {
+    pub fn new(id: ContractId, amount: u64) -> Self {
+        Self { id, amount }
+    }
+}
+
+pub struct AssetPair {
+    a: Asset,
+    b: Asset,
+}
+
+impl AssetPair {
+    pub fn new(a: Asset, b: Asset) -> Self {
+        Self { a, b }
+    }
+
+    pub fn ids(self) -> (ContractId, ContractId) {
+        (self.a.id, self.b.id)
+    }
+
+    pub fn amounts(self) -> (u64, u64) {
+        (self.a.amount, self.b.amount)
+    }
+
+    pub fn this_asset(self, this_asset: ContractId) -> Asset {
+        if this_asset == self.a.id {
+            self.a
+        } else {
+            self.b
+        }
+    }
+
+    pub fn other_asset(self, this_asset: ContractId) -> Asset {
+        if this_asset == self.a.id {
+            self.b
+        } else {
+            self.a
+        }
+    }
+
+    pub fn sort(self, reserves: Self) -> Self {
+        Self {
+            a: if self.a.id == reserves.a.id {
+                self.a
+            } else {
+                self.b
+            },
+            b: if self.a.id == reserves.a.id {
+                self.b
+            } else {
+                self.a
+            },
+        }
+    }
+}
+
+impl core::ops::Add for AssetPair {
+    fn add(self, other: Self) -> Self {
+        Self {
+            a: Asset::new(self.a.id, self.a.amount + other.a.amount),
+            b: Asset::new(self.b.id, self.b.amount + other.b.amount),
+        }
+    }
+}
+
+impl core::ops::Subtract for AssetPair {
+    fn subtract(self, other: Self) -> Self {
+        Self {
+            a: Asset::new(self.a.id, self.a.amount - other.a.amount),
+            b: Asset::new(self.b.id, self.b.amount - other.b.amount),
+        }
+    }
+}
+
+pub struct LiquidityParameters {
+    deposits: AssetPair,
+    liquidity: u64,
+    deadline: u64,
+}
+
 pub struct PoolInfo {
-    /// Unique identifier that makes up one side of the liquidity pool in an exchange contract
-    asset_a: ContractId,
-    /// Unique identifier that makes up the other side of the liquidity pool in an exchange contract
-    asset_b: ContractId,
-    /// The amount of asset a reserve in the exchange contract
-    asset_a_reserve: u64,
-    /// The amount of asset b reserve in the exchange contract
-    asset_b_reserve: u64,
+    /// Unique identifiers and reserve amounts of the assets that make up the liquidity pool of the exchange contract
+    reserves: AssetPair,
     /// The amount of liquidity pool asset supply in the exchange contract
     liquidity: u64,
 }
 
 pub struct PreviewAddLiquidityInfo {
-    /// The amount of other asset to be added to keep the ratio of the assets that make up the pool
+    /// The asset to be added to keep the ratio of the assets that make up the pool
     /// If the ratio is not yet known, i.e., there is no liquidity, then the amount is 0 for preview purposes
-    other_asset_amount_to_add: u64,
-    /// The amount of liquidity pool assets to be minted and transferred to the sender
+    other_asset_to_add: Asset,
+    /// The liquidity pool asset to be minted and transferred to the sender
     /// If the ratio is not yet known, i.e., there is no liquidity, then the ratio is assumed to be 1 for preview purposes
-    liquidity_asset_amount_to_receive: u64,
+    liquidity_asset_to_receive: Asset,
 }
 
 pub struct PreviewSwapInfo {
-    /// The amount of other asset to either input or output for a given swap
-    amount: u64,
+    /// Other asset to either input or output for a given swap
+    other_asset: Asset,
     /// Whether the output reserve is sufficient for swap
     sufficient_reserve: bool,
 }
 
 pub struct RemoveLiquidityInfo {
-    /// The amount of asset a that is removed from the reserves and transferred to the sender
-    asset_a_amount: u64,
-    /// The amount of asset b that is removed from the reserves and transferred to the sender
-    asset_b_amount: u64,
+    /// Pool assets that are removed from the reserves and transferred to the sender
+    removed_amounts: AssetPair,
     /// The amount of liquidity that is burned
-    liquidity: u64,
+    burned_liquidity: Asset,
 }

--- a/AMM/project/libraries/src/interface.sw
+++ b/AMM/project/libraries/src/interface.sw
@@ -2,7 +2,13 @@ library interface;
 
 dep data_structures;
 
-use data_structures::{PoolInfo, PreviewAddLiquidityInfo, PreviewSwapInfo, RemoveLiquidityInfo};
+use data_structures::{
+    Asset,
+    PoolInfo,
+    PreviewAddLiquidityInfo,
+    PreviewSwapInfo,
+    RemoveLiquidityInfo,
+};
 
 abi AMM {
     /// Initialize the AMM by specifying the exchange contract bytecode root, for security.
@@ -67,14 +73,15 @@ abi Exchange {
     ///
     /// # Arguments
     ///
-    /// - `pair` - unique identifiers of the asset pair, i.e., asset A and asset B
+    /// - `asset_a` - unique identifier of one asset
+    /// - `asset_b` - unique identifier of the other asset
     ///
     /// # Reverts
     ///
     /// * When the contract has not been initialized, i.e., asset pair in storage is `None`
     /// * When the passed pair describes identical assets
     #[storage(read, write)]
-    fn constructor(pair: (ContractId, ContractId));
+    fn constructor(asset_a: ContractId, asset_b: ContractId);
 
     /// Deposit asset to later add to the liquidity pool or withdraw.
     ///
@@ -146,8 +153,7 @@ abi Exchange {
     ///
     /// # Arguments
     ///
-    /// - `amount` - the amount of coins to withdraw
-    /// - `asset` - asset to withdraw
+    /// - `asset` - id and amount of asset to withdraw
     ///
     /// # Reverts
     ///
@@ -155,19 +161,19 @@ abi Exchange {
     /// * When the `msg_asset_id` does not identify asset A or asset B
     /// * When the deposited amount by the sender stored in the contract is insufficient
     #[storage(read, write)]
-    fn withdraw(amount: u64, asset: ContractId);
+    fn withdraw(asset: Asset);
 
     /// Get current balance of the sender for a given asset on the contract.
     ///
     /// # Arguments
     ///
-    /// - `asset` - asset to get balance of
+    /// - `asset_id` - asset to get balance of
     ///
     /// # Reverts
     ///
     /// * When the contract has not been initialized, i.e., asset pair in storage is `None`
     #[storage(read)]
-    fn balance(asset: ContractId) -> u64;
+    fn balance(asset_id: ContractId) -> u64;
 
     /// Get the pool info of the exchange contract.
     ///
@@ -192,14 +198,13 @@ abi Exchange {
     ///
     /// # Arguments
     ///
-    /// - `amount` - amount of an asset to add
-    /// - `asset` - asset to add
+    /// - `asset` - id and amount of asset to add
     ///
     /// # Reverts
     ///
     /// * When the contract has not been initialized, i.e., asset pair in storage is `None`
     #[storage(read)]
-    fn preview_add_liquidity(amount: u64, asset: ContractId) -> PreviewAddLiquidityInfo;
+    fn preview_add_liquidity(asset: Asset) -> PreviewAddLiquidityInfo;
 
     /// Get information about the output asset for a `swap_exact_input` without doing the swap operation.
     ///
@@ -209,13 +214,12 @@ abi Exchange {
     ///
     /// # Arguments
     ///
-    /// - `exact_input` - the amount to input
-    /// - `input_asset` - asset to input
+    /// - `exact_input_asset` - the asset to sell
     ///
     /// * When the contract has not been initialized, i.e., asset pair in storage is `None`
     /// * When the `msg_asset_id` does not identify asset A or asset B
     #[storage(read)]
-    fn preview_swap_exact_input(exact_input: u64, input_asset: ContractId) -> PreviewSwapInfo;
+    fn preview_swap_exact_input(exact_input_asset: Asset) -> PreviewSwapInfo;
 
     /// Get information about the input asset for a `swap_exact_output` without doing the swap operation.
     ///
@@ -225,8 +229,7 @@ abi Exchange {
     ///
     /// # Arguments
     ///
-    /// - `exact_output` - the desired amount of other asset to receive after swap
-    /// - `output_asset` - asset to output
+    /// - `exact_output_asset` - the asset to buy
     ///
     /// # Reverts
     ///
@@ -234,5 +237,5 @@ abi Exchange {
     /// * When the `msg_asset_id` does not identify asset A or asset B
     /// * When the `exact_output` is less than the reserve amount of the output asset
     #[storage(read)]
-    fn preview_swap_exact_output(exact_output: u64, output_asset: ContractId) -> PreviewSwapInfo;
+    fn preview_swap_exact_output(exact_output_asset: Asset) -> PreviewSwapInfo;
 }

--- a/AMM/project/scripts/atomic-add-liquidity/Cargo.toml
+++ b/AMM/project/scripts/atomic-add-liquidity/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "atomic-add-liquidity"
+version = "0.0.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dev-dependencies]
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+test-utils = { path = "../../test-utils" }
+tokio = { version = "1.12", features = ["rt", "macros"] }
+
+[[test]]
+harness = true
+name = "tests"
+path = "tests/harness.rs"

--- a/AMM/project/scripts/atomic-add-liquidity/Forc.toml
+++ b/AMM/project/scripts/atomic-add-liquidity/Forc.toml
@@ -1,0 +1,8 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "atomic-add-liquidity"
+
+[dependencies]
+libraries = { path = "../../libraries" }

--- a/AMM/project/scripts/atomic-add-liquidity/src/main.sw
+++ b/AMM/project/scripts/atomic-add-liquidity/src/main.sw
@@ -1,0 +1,35 @@
+script;
+
+use libraries::{data_structures::LiquidityParameters, Exchange};
+
+enum InputError {
+    DesiredLiquidityZero: (),
+}
+
+fn main(
+    exchange_contract_id: ContractId,
+    liquidity_parameters: LiquidityParameters,
+) -> u64 {
+    require(liquidity_parameters.liquidity > 0, InputError::DesiredLiquidityZero);
+
+    let exchange_contract = abi(Exchange, exchange_contract_id.into());
+
+    // deposit first asset
+    exchange_contract.deposit {
+        gas: 70_000,
+        coins: liquidity_parameters.deposits.a.amount,
+        asset_id: liquidity_parameters.deposits.a.id.into(),
+    }();
+
+    // deposit second asset
+    exchange_contract.deposit {
+        gas: 70_000,
+        coins: liquidity_parameters.deposits.b.amount,
+        asset_id: liquidity_parameters.deposits.b.id.into(),
+    }();
+
+    // add liquidity
+    exchange_contract.add_liquidity {
+        gas: 15_000_000,
+    }(liquidity_parameters.liquidity, liquidity_parameters.deadline)
+}

--- a/AMM/project/scripts/atomic-add-liquidity/tests/cases/mod.rs
+++ b/AMM/project/scripts/atomic-add-liquidity/tests/cases/mod.rs
@@ -1,0 +1,2 @@
+mod revert;
+mod success;

--- a/AMM/project/scripts/atomic-add-liquidity/tests/cases/revert.rs
+++ b/AMM/project/scripts/atomic-add-liquidity/tests/cases/revert.rs
@@ -1,0 +1,134 @@
+use crate::utils::{expected_liquidity, setup};
+use fuels::prelude::*;
+use test_utils::interface::{
+    atomic_add_liquidity_script_mod::{Asset, AssetPair},
+    LiquidityParameters, SCRIPT_GAS_LIMIT,
+};
+
+#[tokio::test]
+#[should_panic(expected = "DesiredLiquidityZero")]
+async fn when_desired_liquidity_zero() {
+    let (script_instance, exchange, liquidity_parameters, _transaction_parameters) =
+        setup((1000, 1000), 1000).await;
+
+    script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: 0, // desired liquidity is 0
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .call()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "Revert(18446744073709486080)")]
+// the contract call in the script fails with "DesiredAmountTooHigh" but that message is not propagated
+async fn when_desired_liquidity_too_high() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((1000, 1000), 1000).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
+
+    script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity + 1, //desired liquidity is too high
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "Revert(18446744073709486080)")]
+async fn when_one_deposit_is_zero() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((1000, 1000), 1000).await;
+
+    script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: 0, // deposit amount is 0
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: 1, // if desired liquidity is zero, script will revert with "DesiredLiquidityZero" error
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "Revert(18446744073709486080)")]
+async fn when_both_deposits_are_zero() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((1000, 1000), 1000).await;
+
+    script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: 0, // deposit amount is 0
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: 0, // deposit amount is 0
+                    },
+                },
+                liquidity: 1, // if desired liquidity is zero, script will revert with "DesiredLiquidityZero" error
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap();
+}

--- a/AMM/project/scripts/atomic-add-liquidity/tests/cases/success.rs
+++ b/AMM/project/scripts/atomic-add-liquidity/tests/cases/success.rs
@@ -1,0 +1,391 @@
+use crate::utils::{expected_liquidity, setup};
+use fuels::prelude::*;
+use test_utils::{
+    data_structures::LiquidityParameters as TestLiquidityParameters,
+    interface::{
+        atomic_add_liquidity_script_mod::{Asset, AssetPair},
+        LiquidityParameters, SCRIPT_GAS_LIMIT,
+    },
+    setup::common::deposit_and_add_liquidity,
+};
+
+#[tokio::test]
+async fn adds_liquidity_with_equal_deposit_amounts() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((1000, 1000), 1000).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
+
+    // add initial liquidity with amounts 1000:1000
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}
+
+#[tokio::test]
+async fn adds_liquidity_to_make_a_more_valuable() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((1000, 2000), 1000).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
+
+    // add initial liquidity with amounts 1000:2000
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}
+
+#[tokio::test]
+async fn adds_liquidity_to_make_b_more_valuable() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((2000, 1000), 1000).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
+
+    // add initial liquidity with amounts 2000:1000
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}
+
+#[tokio::test]
+async fn adds_further_liquidity_without_extra_deposit_when_a_is_more_valuable() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((1000, 4000), 2000).await;
+
+    // add initial liquidity with amounts 1000:4000
+    let initial_liquidity_parameters = TestLiquidityParameters::new(
+        Some((1000, 4000)),
+        Some(liquidity_parameters.deadline),
+        Some(2000),
+    );
+    deposit_and_add_liquidity(&initial_liquidity_parameters, &exchange, false).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
+
+    // add further liquidity with amounts 1000:4000 i.e. no extra deposit
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}
+
+#[tokio::test]
+async fn adds_further_liquidity_with_extra_a_deposit_when_a_is_more_valuable() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((200, 400), 200).await;
+
+    // add initial liquidity with amounts 1000:4000
+    let initial_liquidity_parameters = TestLiquidityParameters::new(
+        Some((1000, 4000)),
+        Some(liquidity_parameters.deadline),
+        Some(2000),
+    );
+    deposit_and_add_liquidity(&initial_liquidity_parameters, &exchange, false).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
+
+    // add further liquidity with amounts 200:400 i.e. depositing extra 100 of asset A
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}
+
+#[tokio::test]
+async fn adds_further_liquidity_with_extra_b_deposit_when_a_is_more_valuable() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((100, 500), 200).await;
+
+    // add initial liquidity with amounts 1000:4000
+    let initial_liquidity_parameters = TestLiquidityParameters::new(
+        Some((1000, 4000)),
+        Some(liquidity_parameters.deadline),
+        Some(2000),
+    );
+    deposit_and_add_liquidity(&initial_liquidity_parameters, &exchange, false).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, true).await;
+
+    // add further liquidity with amounts 100:500 i.e. depositing extra 100 of asset B
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}
+
+#[tokio::test]
+async fn adds_further_liquidity_without_extra_deposit_when_b_is_more_valuable() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((400, 100), 200).await;
+
+    // add initial liquidity with amounts 4000:1000
+    let initial_liquidity_parameters = TestLiquidityParameters::new(
+        Some((4000, 1000)),
+        Some(liquidity_parameters.deadline),
+        Some(2000),
+    );
+    deposit_and_add_liquidity(&initial_liquidity_parameters, &exchange, false).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
+
+    // add further liquidity with amounts 400:100 i.e. no extra deposit
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}
+
+#[tokio::test]
+async fn adds_further_liquidity_with_extra_a_deposit_when_b_is_more_valuable() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((500, 100), 200).await;
+
+    // add initial liquidity with amounts 4000:1000
+    let initial_liquidity_parameters = TestLiquidityParameters::new(
+        Some((4000, 1000)),
+        Some(liquidity_parameters.deadline),
+        Some(2000),
+    );
+    deposit_and_add_liquidity(&initial_liquidity_parameters, &exchange, false).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
+
+    // add further liquidity with amounts 500:100 i.e. depositing extra 100 of asset A
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}
+
+#[tokio::test]
+async fn adds_further_liquidity_with_extra_b_deposit_when_b_is_more_valuable() {
+    let (script_instance, exchange, liquidity_parameters, transaction_parameters) =
+        setup((400, 200), 200).await;
+
+    // add initial liquidity with amounts 4000:1000
+    let initial_liquidity_parameters = TestLiquidityParameters::new(
+        Some((4000, 1000)),
+        Some(liquidity_parameters.deadline),
+        Some(2000),
+    );
+    deposit_and_add_liquidity(&initial_liquidity_parameters, &exchange, false).await;
+
+    let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, true).await;
+
+    // add further liquidity with amounts 400:200 i.e. depositing extra 100 of asset B
+    let liquidity = script_instance
+        .main(
+            exchange.id,
+            LiquidityParameters {
+                deposits: AssetPair {
+                    a: Asset {
+                        id: ContractId::new(*exchange.pair.0),
+                        amount: liquidity_parameters.amounts.0,
+                    },
+                    b: Asset {
+                        id: ContractId::new(*exchange.pair.1),
+                        amount: liquidity_parameters.amounts.1,
+                    },
+                },
+                liquidity: expected_liquidity,
+                deadline: liquidity_parameters.deadline,
+            },
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    assert_eq!(expected_liquidity, liquidity);
+}

--- a/AMM/project/scripts/atomic-add-liquidity/tests/harness.rs
+++ b/AMM/project/scripts/atomic-add-liquidity/tests/harness.rs
@@ -1,0 +1,2 @@
+mod cases;
+mod utils;

--- a/AMM/project/scripts/atomic-add-liquidity/tests/utils/mod.rs
+++ b/AMM/project/scripts/atomic-add-liquidity/tests/utils/mod.rs
@@ -1,0 +1,116 @@
+use test_utils::{
+    data_structures::{
+        ExchangeContract, ExchangeContractConfiguration, LiquidityParameters,
+        TransactionParameters, WalletAssetConfiguration,
+    },
+    interface::{
+        exchange::{deposit, preview_add_liquidity, withdraw},
+        AtomicAddLiquidityScript,
+    },
+    paths::ATOMIC_ADD_LIQUIDITY_SCRIPT_BINARY_PATH,
+    setup::{
+        common::{deploy_and_construct_exchange, setup_wallet_and_provider},
+        scripts::transaction_inputs_outputs,
+    },
+};
+
+pub async fn expected_liquidity(
+    exchange: &ExchangeContract,
+    liquidity_parameters: &LiquidityParameters,
+    override_asset: bool,
+) -> u64 {
+    deposit(
+        &exchange.instance,
+        if override_asset {
+            liquidity_parameters.amounts.1
+        } else {
+            liquidity_parameters.amounts.0
+        },
+        if override_asset {
+            exchange.pair.1
+        } else {
+            exchange.pair.0
+        },
+    )
+    .await;
+
+    let preview_add_liquidity_info = preview_add_liquidity(
+        &exchange.instance,
+        if override_asset {
+            liquidity_parameters.amounts.0
+        } else {
+            liquidity_parameters.amounts.1
+        },
+        if override_asset {
+            exchange.pair.0
+        } else {
+            exchange.pair.1
+        },
+        true,
+    )
+    .await;
+
+    withdraw(
+        &exchange.instance,
+        if override_asset {
+            liquidity_parameters.amounts.1
+        } else {
+            liquidity_parameters.amounts.0
+        },
+        if override_asset {
+            exchange.pair.1
+        } else {
+            exchange.pair.0
+        },
+    )
+    .await;
+
+    preview_add_liquidity_info.liquidity_asset_to_receive.amount
+}
+
+pub async fn setup(
+    deposit_amounts: (u64, u64),
+    liquidity: u64,
+) -> (
+    AtomicAddLiquidityScript,
+    ExchangeContract,
+    LiquidityParameters,
+    TransactionParameters,
+) {
+    let (wallet, asset_ids, provider) =
+        setup_wallet_and_provider(&WalletAssetConfiguration::default()).await;
+
+    let exchange = deploy_and_construct_exchange(
+        &wallet,
+        &ExchangeContractConfiguration::new(Some((asset_ids[0], asset_ids[1])), None, None, None),
+    )
+    .await;
+
+    let liquidity_parameters = LiquidityParameters::new(
+        Some(deposit_amounts),
+        Some(provider.latest_block_height().await.unwrap() + 10),
+        Some(liquidity),
+    );
+
+    let transaction_parameters = transaction_inputs_outputs(
+        &wallet,
+        &provider,
+        &vec![exchange.id],
+        &vec![*asset_ids.get(0).unwrap(), *asset_ids.get(1).unwrap()],
+        Some(&vec![
+            liquidity_parameters.amounts.0,
+            liquidity_parameters.amounts.1,
+        ]),
+    )
+    .await;
+
+    let script_instance =
+        AtomicAddLiquidityScript::new(wallet, ATOMIC_ADD_LIQUIDITY_SCRIPT_BINARY_PATH);
+
+    (
+        script_instance,
+        exchange,
+        liquidity_parameters,
+        transaction_parameters,
+    )
+}

--- a/AMM/project/scripts/swap-exact-input/Cargo.toml
+++ b/AMM/project/scripts/swap-exact-input/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "swap-exact-input"
+version = "0.0.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dev-dependencies]
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+test-utils = { path = "../../test-utils" }
+tokio = { version = "1.12", features = ["rt", "macros"] }
+
+[[test]]
+harness = true
+name = "tests"
+path = "tests/harness.rs"

--- a/AMM/project/scripts/swap-exact-input/Forc.toml
+++ b/AMM/project/scripts/swap-exact-input/Forc.toml
@@ -1,0 +1,11 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "swap-exact-input"
+
+[constants]
+AMM_ID = { type = "b256", value = "0x7c1420f4d30178fdff677e7b718ab20fdf4c0dbca78d3b9602ee8cabe50349cb" }
+
+[dependencies]
+libraries = { path = "../../libraries" }

--- a/AMM/project/scripts/swap-exact-input/src/main.sw
+++ b/AMM/project/scripts/swap-exact-input/src/main.sw
@@ -1,0 +1,58 @@
+script;
+
+use libraries::{AMM, Exchange};
+
+enum InputError {
+    RouteTooShort: (),
+}
+
+enum SwapError {
+    ExcessiveSlippage: u64,
+    PairExchangeNotRegistered: (ContractId, ContractId),
+}
+
+fn main(
+    assets: Vec<ContractId>,
+    input_amount: u64,
+    minimum_output_amount: Option<u64>,
+    deadline: u64,
+) -> u64 {
+    require(assets.len() >= 2, InputError::RouteTooShort);
+
+    let amm_contract = abi(AMM, AMM_ID);
+
+    let mut latest_bought = input_amount;
+
+    // start swapping by selling the first asset in the route
+    let mut sold_asset_index = 0;
+
+    // swap subsequent asset pairs along route
+    while sold_asset_index < assets.len - 1 {
+        let asset_pair = (
+            assets.get(sold_asset_index).unwrap(),
+            assets.get(sold_asset_index + 1).unwrap(),
+        );
+
+        // get the exchange contract id of asset pair
+        let exchange_contract_id = amm_contract.pool { gas: 100_000 }(asset_pair);
+
+        require(exchange_contract_id.is_some(), SwapError::PairExchangeNotRegistered(asset_pair));
+
+        let exchange_contract = abi(Exchange, exchange_contract_id.unwrap().into());
+
+        // swap by specifying the exact amount to sell
+        latest_bought = exchange_contract.swap_exact_input {
+            gas: 10_000_000,
+            coins: latest_bought, // forwarding coins of asset to sell
+            asset_id: asset_pair.0.into(), // identifier of asset to sell
+        }(Option::None::<u64>(), deadline);
+
+        sold_asset_index += 1;
+    }
+
+    if minimum_output_amount.is_some() {
+        require(latest_bought >= minimum_output_amount.unwrap(), SwapError::ExcessiveSlippage(latest_bought));
+    }
+
+    latest_bought
+}

--- a/AMM/project/scripts/swap-exact-input/tests/cases/mod.rs
+++ b/AMM/project/scripts/swap-exact-input/tests/cases/mod.rs
@@ -1,0 +1,2 @@
+mod revert;
+mod success;

--- a/AMM/project/scripts/swap-exact-input/tests/cases/revert.rs
+++ b/AMM/project/scripts/swap-exact-input/tests/cases/revert.rs
@@ -1,0 +1,134 @@
+use crate::utils::{expected_and_actual_output, expected_swap_output, setup};
+use fuels::prelude::*;
+use test_utils::{
+    data_structures::{SwapParameters, NUMBER_OF_ASSETS},
+    interface::SCRIPT_GAS_LIMIT,
+};
+
+#[tokio::test]
+#[should_panic(expected = "RouteTooShort")]
+async fn when_route_length_is_zero() {
+    expected_and_actual_output(SwapParameters {
+        amount: 10,
+        route_length: 0,
+    })
+    .await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "RouteTooShort")]
+async fn when_route_length_is_one() {
+    expected_and_actual_output(SwapParameters {
+        amount: 10,
+        route_length: 1,
+    })
+    .await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "PairExchangeNotRegistered")]
+async fn when_pair_exchange_not_registered() {
+    let (script_instance, _amm, asset_ids, transaction_parameters, deadline) = setup().await;
+
+    let mut route = asset_ids;
+    let input_amount = 60;
+
+    // make sure that the first asset in the route does not have a pool
+    let not_registered_asset_id = AssetId::from([1u8; 32]);
+    route.remove(0);
+    route.insert(0, not_registered_asset_id);
+
+    script_instance
+        .main(
+            route
+                .into_iter()
+                .map(|asset_id| ContractId::new(*asset_id))
+                .collect(),
+            input_amount,
+            None,
+            deadline,
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .call()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "Revert(18446744073709486080)")]
+// the contract call in the script fails with "DeadlinePassed" but that message is not propagated
+async fn when_deadline_passed() {
+    let (script_instance, amm, asset_ids, transaction_parameters, _deadline) = setup().await;
+
+    let route = asset_ids;
+    let input_amount = 60;
+
+    let expected_result = expected_swap_output(&amm, input_amount, &route).await;
+
+    script_instance
+        .main(
+            route
+                .into_iter()
+                .map(|asset_id| ContractId::new(*asset_id))
+                .collect(),
+            input_amount,
+            Some(expected_result),
+            0, // deadline is 0
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "ExcessiveSlippage")]
+async fn when_minimum_output_not_satisfied() {
+    let (script_instance, amm, asset_ids, transaction_parameters, deadline) = setup().await;
+
+    let route = asset_ids;
+    let input_amount = 60;
+
+    let expected_result = expected_swap_output(&amm, input_amount, &route).await;
+
+    script_instance
+        .main(
+            route
+                .into_iter()
+                .map(|asset_id| ContractId::new(*asset_id))
+                .collect(),
+            input_amount,
+            Some(expected_result + 1), // setting the minimum to be higher than what it can be
+            deadline,
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "Revert(18446744073709486080)")]
+async fn when_input_is_zero() {
+    expected_and_actual_output(SwapParameters {
+        amount: 0,
+        route_length: 2,
+    })
+    .await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "Revert(18446744073709486080)")]
+// fails because starting with the second swap, the swap input is 0 which is not allowed
+async fn when_input_is_one_and_route_has_more_than_two_assets() {
+    expected_and_actual_output(SwapParameters {
+        amount: 1,
+        route_length: NUMBER_OF_ASSETS,
+    })
+    .await;
+}

--- a/AMM/project/scripts/swap-exact-input/tests/cases/success.rs
+++ b/AMM/project/scripts/swap-exact-input/tests/cases/success.rs
@@ -1,0 +1,68 @@
+use crate::utils::expected_and_actual_output;
+use test_utils::data_structures::{SwapParameters, NUMBER_OF_ASSETS};
+
+#[tokio::test]
+async fn can_swap_exact_input_along_route_small_input() {
+    let swap_result = expected_and_actual_output(SwapParameters {
+        amount: 2,
+        route_length: NUMBER_OF_ASSETS,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_input_along_route_middle_input() {
+    let swap_result = expected_and_actual_output(SwapParameters {
+        amount: 60,
+        route_length: NUMBER_OF_ASSETS,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_input_along_route_large_input() {
+    let swap_result = expected_and_actual_output(SwapParameters {
+        amount: 10_000,
+        route_length: NUMBER_OF_ASSETS,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_input_two_assets_small_input() {
+    let swap_result = expected_and_actual_output(SwapParameters {
+        amount: 1,
+        route_length: 2,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_input_two_assets_middle_input() {
+    let swap_result = expected_and_actual_output(SwapParameters {
+        amount: 60,
+        route_length: 2,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_input_two_assets_large_input() {
+    let swap_result = expected_and_actual_output(SwapParameters {
+        amount: 10_000,
+        route_length: 2,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}

--- a/AMM/project/scripts/swap-exact-input/tests/harness.rs
+++ b/AMM/project/scripts/swap-exact-input/tests/harness.rs
@@ -1,0 +1,2 @@
+mod cases;
+mod utils;

--- a/AMM/project/scripts/swap-exact-input/tests/utils/mod.rs
+++ b/AMM/project/scripts/swap-exact-input/tests/utils/mod.rs
@@ -1,0 +1,102 @@
+use fuels::prelude::*;
+use test_utils::{
+    data_structures::{
+        AMMContract, SwapParameters, SwapResult, TransactionParameters, WalletAssetConfiguration,
+    },
+    interface::{exchange::preview_swap_exact_input, SwapExactInputScript, SCRIPT_GAS_LIMIT},
+    paths::SWAP_EXACT_INPUT_SCRIPT_BINARY_PATH,
+    setup::{
+        common::{deploy_and_initialize_amm, setup_wallet_and_provider},
+        scripts::{setup_exchange_contracts, transaction_inputs_outputs},
+    },
+};
+
+pub async fn expected_swap_output(
+    amm: &AMMContract,
+    input_amount: u64,
+    route: &Vec<AssetId>,
+) -> u64 {
+    assert!(route.len() >= 2);
+    let (mut i, mut latest_output) = (0, input_amount);
+
+    while i < route.len() - 1 {
+        let pair = (*route.get(i).unwrap(), *route.get(i + 1).unwrap());
+        let exchange = &amm.pools.get(&pair).unwrap().instance;
+        latest_output = preview_swap_exact_input(&exchange, latest_output, pair.0, true)
+            .await
+            .other_asset
+            .amount;
+        i += 1;
+    }
+    latest_output
+}
+
+pub async fn expected_and_actual_output(swap_parameters: SwapParameters) -> SwapResult {
+    let (script_instance, amm, asset_ids, transaction_parameters, deadline) = setup().await;
+
+    let mut route = Vec::with_capacity(swap_parameters.route_length as usize);
+    let mut asset_index = 0;
+    while asset_index < swap_parameters.route_length {
+        route.push(*asset_ids.get(asset_index as usize).unwrap());
+        asset_index += 1;
+    }
+
+    let expected = if swap_parameters.route_length >= 2 {
+        Some(expected_swap_output(&amm, swap_parameters.amount, &route).await)
+    } else {
+        None
+    };
+
+    let actual = script_instance
+        .main(
+            route
+                .into_iter()
+                .map(|asset_id| ContractId::new(*asset_id))
+                .collect(),
+            swap_parameters.amount,
+            expected,
+            deadline,
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    SwapResult { actual, expected }
+}
+
+pub async fn setup() -> (
+    SwapExactInputScript,
+    AMMContract,
+    Vec<AssetId>,
+    TransactionParameters,
+    u64,
+) {
+    let (wallet, asset_ids, provider) =
+        setup_wallet_and_provider(&WalletAssetConfiguration::default()).await;
+
+    let mut amm = deploy_and_initialize_amm(&wallet).await;
+
+    setup_exchange_contracts(&wallet, &provider, &mut amm, &asset_ids).await;
+
+    let mut contracts = vec![amm.id];
+    contracts.extend(amm.pools.values().into_iter().map(|exchange| exchange.id));
+
+    let transaction_parameters =
+        transaction_inputs_outputs(&wallet, &provider, &contracts, &asset_ids, None).await;
+
+    let deadline = provider.latest_block_height().await.unwrap() + 10;
+
+    let script_instance = SwapExactInputScript::new(wallet, SWAP_EXACT_INPUT_SCRIPT_BINARY_PATH);
+
+    (
+        script_instance,
+        amm,
+        asset_ids,
+        transaction_parameters,
+        deadline,
+    )
+}

--- a/AMM/project/scripts/swap-exact-output/Cargo.toml
+++ b/AMM/project/scripts/swap-exact-output/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "swap-exact-output"
+version = "0.0.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dev-dependencies]
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+test-utils = { path = "../../test-utils" }
+tokio = { version = "1.12", features = ["rt", "macros"] }
+
+[[test]]
+harness = true
+name = "tests"
+path = "tests/harness.rs"

--- a/AMM/project/scripts/swap-exact-output/Forc.toml
+++ b/AMM/project/scripts/swap-exact-output/Forc.toml
@@ -1,0 +1,11 @@
+[project]
+authors = ["Fuel Labs <contact@fuel.sh>"]
+entry = "main.sw"
+license = "Apache-2.0"
+name = "swap-exact-output"
+
+[dependencies]
+libraries = { path = "../../libraries" }
+
+[constants]
+AMM_ID = { type = "b256", value = "0x7c1420f4d30178fdff677e7b718ab20fdf4c0dbca78d3b9602ee8cabe50349cb" }

--- a/AMM/project/scripts/swap-exact-output/src/main.sw
+++ b/AMM/project/scripts/swap-exact-output/src/main.sw
@@ -1,0 +1,59 @@
+script;
+
+use libraries::{AMM, data_structures::Asset, Exchange};
+
+enum InputError {
+    RouteTooShort: (),
+}
+
+enum SwapError {
+    ExcessiveSlippage: u64,
+    PairExchangeNotRegistered: (ContractId, ContractId),
+}
+
+fn main(
+    assets: Vec<ContractId>,
+    output_amount: u64,
+    maximum_input_amount: u64,
+    deadline: u64,
+) -> u64 {
+    require(assets.len() >= 2, InputError::RouteTooShort);
+
+    let amm_contract = abi(AMM, AMM_ID);
+
+    let mut latest_sold = output_amount;
+
+    // start swapping by buying the last asset in the route
+    let mut bought_asset_index = assets.len() - 1;
+
+    // swap subsequent asset pairs along route
+    while bought_asset_index > 0 {
+        let asset_pair = (
+            assets.get(bought_asset_index - 1).unwrap(),
+            assets.get(bought_asset_index).unwrap(),
+        );
+
+        // get the exchange contract id of asset pair
+        let exchange_contract_id = amm_contract.pool { gas: 100_000 }(asset_pair);
+
+        require(exchange_contract_id.is_some(), SwapError::PairExchangeNotRegistered(asset_pair));
+
+        let exchange_contract = abi(Exchange, exchange_contract_id.unwrap().into());
+
+        let preview = exchange_contract.preview_swap_exact_output(Asset::new(asset_pair.1, latest_sold));
+        let sell_amount = preview.other_asset.amount;
+
+        // swap by specifying the exact amount to buy
+        latest_sold = exchange_contract.swap_exact_output {
+            gas: 10_000_000,
+            coins: sell_amount, // forward coins of asset to sell
+            asset_id: asset_pair.0.into(), // identifier of asset to sell
+        }(latest_sold, deadline);
+
+        bought_asset_index -= 1;
+    }
+
+    require(latest_sold <= maximum_input_amount, SwapError::ExcessiveSlippage(latest_sold));
+
+    latest_sold
+}

--- a/AMM/project/scripts/swap-exact-output/tests/cases/mod.rs
+++ b/AMM/project/scripts/swap-exact-output/tests/cases/mod.rs
@@ -1,0 +1,2 @@
+mod revert;
+mod success;

--- a/AMM/project/scripts/swap-exact-output/tests/cases/revert.rs
+++ b/AMM/project/scripts/swap-exact-output/tests/cases/revert.rs
@@ -1,0 +1,132 @@
+use crate::utils::{expected_and_actual_input, expected_swap_input, setup};
+use fuels::prelude::*;
+use test_utils::{
+    data_structures::{SwapParameters, NUMBER_OF_ASSETS},
+    interface::SCRIPT_GAS_LIMIT,
+};
+
+#[tokio::test]
+#[should_panic(expected = "RouteTooShort")]
+async fn when_route_length_is_zero() {
+    expected_and_actual_input(SwapParameters {
+        amount: 0,
+        route_length: 0,
+    })
+    .await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "RouteTooShort")]
+async fn when_route_length_is_one() {
+    expected_and_actual_input(SwapParameters {
+        amount: 0,
+        route_length: 1,
+    })
+    .await;
+}
+
+#[tokio::test]
+#[should_panic(expected = "PairExchangeNotRegistered")]
+async fn when_pair_exchange_not_registered() {
+    let (script_instance, _amm, asset_ids, transaction_parameters, deadline) = setup().await;
+
+    let mut route = asset_ids;
+    let output_amount = 10_000;
+    let maximum_input_amount = 0;
+
+    // make sure that the first asset in the route does not have a pool
+    let not_registered_asset_id = AssetId::from([1u8; 32]);
+    route.remove(route.len() - 1);
+    route.push(not_registered_asset_id);
+
+    script_instance
+        .main(
+            route
+                .into_iter()
+                .map(|asset_id| ContractId::new(*asset_id))
+                .collect(),
+            output_amount,
+            maximum_input_amount,
+            deadline,
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .call()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "Revert(18446744073709486080)")]
+// the contract call in the script fails with "DeadlinePassed" but that message is not propagated
+async fn when_deadline_passed() {
+    let (script_instance, amm, asset_ids, transaction_parameters, _deadline) = setup().await;
+
+    let route = asset_ids;
+    let output_amount = 10_000;
+    let maximum_input_amount = expected_swap_input(&amm, output_amount, &route).await;
+
+    script_instance
+        .main(
+            route
+                .into_iter()
+                .map(|asset_id| ContractId::new(*asset_id))
+                .collect(),
+            output_amount,
+            maximum_input_amount,
+            0, // deadline is 0
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[should_panic(expected = "ExcessiveSlippage")]
+async fn when_maximum_input_not_satisfied() {
+    let (script_instance, amm, asset_ids, transaction_parameters, deadline) = setup().await;
+
+    let route = asset_ids;
+    let output_amount = 10_000;
+    let maximum_input_amount = expected_swap_input(&amm, output_amount, &route).await;
+
+    script_instance
+        .main(
+            route
+                .into_iter()
+                .map(|asset_id| ContractId::new(*asset_id))
+                .collect(),
+            output_amount,
+            maximum_input_amount - 1, // setting the maximum to be lower than what it can be
+            deadline,
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap();
+}
+
+#[should_panic(expected = "DesiredAmountTooLow")]
+#[tokio::test]
+async fn when_requested_swap_output_is_zero() {
+    expected_and_actual_input(SwapParameters {
+        amount: 0,
+        route_length: 2,
+    })
+    .await;
+}
+
+#[should_panic(expected = "DesiredAmountTooLow")]
+#[tokio::test]
+async fn when_requested_swap_output_is_too_low() {
+    expected_and_actual_input(SwapParameters {
+        amount: 1,
+        route_length: NUMBER_OF_ASSETS,
+    })
+    .await;
+}

--- a/AMM/project/scripts/swap-exact-output/tests/cases/success.rs
+++ b/AMM/project/scripts/swap-exact-output/tests/cases/success.rs
@@ -1,0 +1,68 @@
+use crate::utils::expected_and_actual_input;
+use test_utils::data_structures::{SwapParameters, NUMBER_OF_ASSETS};
+
+#[tokio::test]
+async fn can_swap_exact_output_along_route_small_input() {
+    let swap_result = expected_and_actual_input(SwapParameters {
+        amount: 8, // smallest output that can be requested for this setup of exchanges
+        route_length: NUMBER_OF_ASSETS,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_output_along_route_middle_input() {
+    let swap_result = expected_and_actual_input(SwapParameters {
+        amount: 60,
+        route_length: NUMBER_OF_ASSETS,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_output_along_route_large_input() {
+    let swap_result = expected_and_actual_input(SwapParameters {
+        amount: 10_000,
+        route_length: NUMBER_OF_ASSETS,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_output_two_assets_small_input() {
+    let swap_result = expected_and_actual_input(SwapParameters {
+        amount: 1,
+        route_length: 2,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_output_two_assets_middle_input() {
+    let swap_result = expected_and_actual_input(SwapParameters {
+        amount: 60,
+        route_length: 2,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}
+
+#[tokio::test]
+async fn can_swap_exact_output_two_assets_large_input() {
+    let swap_result = expected_and_actual_input(SwapParameters {
+        amount: 10_000,
+        route_length: 2,
+    })
+    .await;
+
+    assert_eq!(swap_result.expected.unwrap(), swap_result.actual);
+}

--- a/AMM/project/scripts/swap-exact-output/tests/harness.rs
+++ b/AMM/project/scripts/swap-exact-output/tests/harness.rs
@@ -1,0 +1,2 @@
+mod cases;
+mod utils;

--- a/AMM/project/scripts/swap-exact-output/tests/utils/mod.rs
+++ b/AMM/project/scripts/swap-exact-output/tests/utils/mod.rs
@@ -1,0 +1,102 @@
+use fuels::prelude::*;
+use test_utils::{
+    data_structures::{
+        AMMContract, SwapParameters, SwapResult, TransactionParameters, WalletAssetConfiguration,
+    },
+    interface::{exchange::preview_swap_exact_output, SwapExactOutputScript, SCRIPT_GAS_LIMIT},
+    paths::SWAP_EXACT_OUTPUT_SCRIPT_BINARY_PATH,
+    setup::{
+        common::{deploy_and_initialize_amm, setup_wallet_and_provider},
+        scripts::{setup_exchange_contracts, transaction_inputs_outputs},
+    },
+};
+
+pub async fn expected_swap_input(
+    amm: &AMMContract,
+    output_amount: u64,
+    route: &Vec<AssetId>,
+) -> u64 {
+    assert!(route.len() >= 2);
+    let (mut i, mut latest_input) = (route.len() - 1, output_amount);
+
+    while i > 0 {
+        let pair = (*route.get(i - 1).unwrap(), *route.get(i).unwrap());
+        let exchange = &amm.pools.get(&pair).unwrap().instance;
+        latest_input = preview_swap_exact_output(&exchange, latest_input, pair.1, true)
+            .await
+            .other_asset
+            .amount;
+        i -= 1;
+    }
+    latest_input
+}
+
+pub async fn expected_and_actual_input(swap_parameters: SwapParameters) -> SwapResult {
+    let (script_instance, amm, asset_ids, transaction_parameters, deadline) = setup().await;
+
+    let mut route = Vec::with_capacity(swap_parameters.route_length as usize);
+    let mut asset_index = 0;
+    while asset_index < swap_parameters.route_length {
+        route.push(*asset_ids.get(asset_index as usize).unwrap());
+        asset_index += 1;
+    }
+
+    let expected = if swap_parameters.route_length >= 2 {
+        Some(expected_swap_input(&amm, swap_parameters.amount, &route).await)
+    } else {
+        None
+    };
+
+    let actual = script_instance
+        .main(
+            route
+                .into_iter()
+                .map(|asset_id| ContractId::new(*asset_id))
+                .collect(),
+            swap_parameters.amount,
+            expected.unwrap_or(0),
+            deadline,
+        )
+        .with_inputs(transaction_parameters.inputs)
+        .with_outputs(transaction_parameters.outputs)
+        .tx_params(TxParameters::new(None, Some(SCRIPT_GAS_LIMIT), None))
+        .call()
+        .await
+        .unwrap()
+        .value;
+
+    SwapResult { actual, expected }
+}
+
+pub async fn setup() -> (
+    SwapExactOutputScript,
+    AMMContract,
+    Vec<AssetId>,
+    TransactionParameters,
+    u64,
+) {
+    let (wallet, asset_ids, provider) =
+        setup_wallet_and_provider(&WalletAssetConfiguration::default()).await;
+
+    let mut amm = deploy_and_initialize_amm(&wallet).await;
+
+    setup_exchange_contracts(&wallet, &provider, &mut amm, &asset_ids).await;
+
+    let mut contracts = vec![amm.id];
+    contracts.extend(amm.pools.values().into_iter().map(|exchange| exchange.id));
+
+    let transaction_parameters =
+        transaction_inputs_outputs(&wallet, &provider, &contracts, &asset_ids, None).await;
+
+    let deadline = provider.latest_block_height().await.unwrap() + 10;
+
+    let script_instance = SwapExactOutputScript::new(wallet, SWAP_EXACT_OUTPUT_SCRIPT_BINARY_PATH);
+
+    (
+        script_instance,
+        amm,
+        asset_ids,
+        transaction_parameters,
+        deadline,
+    )
+}

--- a/AMM/project/test-utils/Cargo.toml
+++ b/AMM/project/test-utils/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "test-utils"
+version = "0.0.0"
+authors = ["Fuel Labs <contact@fuel.sh>"]
+edition = "2021"
+license = "Apache-2.0"
+
+[dependencies]
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+
+[lib]
+doctest = false

--- a/AMM/project/test-utils/src/data_structures.rs
+++ b/AMM/project/test-utils/src/data_structures.rs
@@ -1,0 +1,96 @@
+use super::interface::{Exchange, AMM};
+use fuels::{
+    prelude::*,
+    tx::{Input, Output},
+};
+use std::collections::HashMap;
+
+const AMOUNT_PER_COIN: u64 = 1_000_000;
+const COINS_PER_ASSET: u64 = 100;
+const DEADLINE: u64 = 1000;
+const DEPOSIT_AMOUNTS: (u64, u64) = (10000, 40000);
+const LIQUIDITY: u64 = 20000;
+pub const NUMBER_OF_ASSETS: u64 = 5;
+
+pub struct AMMContract {
+    pub id: ContractId,
+    pub instance: AMM,
+    pub pools: HashMap<(AssetId, AssetId), ExchangeContract>,
+}
+
+pub struct ExchangeContract {
+    pub bytecode_root: Option<ContractId>,
+    pub id: ContractId,
+    pub instance: Exchange,
+    pub pair: (AssetId, AssetId),
+}
+
+pub struct ExchangeContractConfiguration {
+    pub pair: (AssetId, AssetId),
+    pub compute_bytecode_root: bool,
+    pub malicious: bool,
+    pub salt: [u8; 32],
+}
+
+pub struct LiquidityParameters {
+    pub amounts: (u64, u64),
+    pub deadline: u64,
+    pub liquidity: u64,
+}
+
+pub struct TransactionParameters {
+    pub inputs: Vec<Input>,
+    pub outputs: Vec<Output>,
+}
+
+pub struct WalletAssetConfiguration {
+    pub number_of_assets: u64,
+    pub coins_per_asset: u64,
+    pub amount_per_coin: u64,
+}
+
+impl ExchangeContractConfiguration {
+    pub fn new(
+        pair: Option<(AssetId, AssetId)>,
+        compute_bytecode_root: Option<bool>,
+        malicious: Option<bool>,
+        salt: Option<[u8; 32]>,
+    ) -> Self {
+        Self {
+            pair: pair.unwrap_or_default(),
+            compute_bytecode_root: compute_bytecode_root.unwrap_or_default(),
+            malicious: malicious.unwrap_or_default(),
+            salt: salt.unwrap_or_default(),
+        }
+    }
+}
+
+impl LiquidityParameters {
+    pub fn new(amounts: Option<(u64, u64)>, deadline: Option<u64>, liquidity: Option<u64>) -> Self {
+        Self {
+            amounts: amounts.unwrap_or(DEPOSIT_AMOUNTS),
+            deadline: deadline.unwrap_or(DEADLINE),
+            liquidity: liquidity.unwrap_or(LIQUIDITY),
+        }
+    }
+}
+
+pub struct SwapParameters {
+    pub amount: u64,
+    pub route_length: u64,
+}
+
+pub struct SwapResult {
+    pub actual: u64,
+    pub expected: Option<u64>,
+}
+
+impl Default for WalletAssetConfiguration {
+    fn default() -> Self {
+        Self {
+            number_of_assets: NUMBER_OF_ASSETS,
+            coins_per_asset: COINS_PER_ASSET,
+            amount_per_coin: AMOUNT_PER_COIN,
+        }
+    }
+}

--- a/AMM/project/test-utils/src/interface.rs
+++ b/AMM/project/test-utils/src/interface.rs
@@ -1,0 +1,324 @@
+use fuels::prelude::*;
+
+abigen!(
+    AMM,
+    "./project/contracts/AMM-contract/out/debug/AMM-contract-abi.json"
+);
+
+abigen!(
+    Exchange,
+    "./project/contracts/exchange-contract/out/debug/exchange-contract-abi.json"
+);
+
+script_abigen!(
+    AtomicAddLiquidityScript,
+    "./project/scripts/atomic-add-liquidity/out/debug/atomic-add-liquidity-abi.json"
+);
+
+script_abigen!(
+    SwapExactInputScript,
+    "./project/scripts/swap-exact-input/out/debug/swap-exact-input-abi.json"
+);
+
+script_abigen!(
+    SwapExactOutputScript,
+    "./project/scripts/swap-exact-output/out/debug/swap-exact-output-abi.json"
+);
+
+pub const SCRIPT_GAS_LIMIT: u64 = 100_000_000; // TODO: hardcoded until scripts have gas estimation
+const GAS_TOLERANCE: f64 = 20.0; // TODO: this should be closer to 0.0. gas estimation issue is under investigation
+
+pub mod amm {
+    use super::*;
+
+    pub async fn initialize(contract: &AMM, exchange_bytecode_root: ContractId) {
+        contract
+            .methods()
+            .initialize(exchange_bytecode_root)
+            .call()
+            .await
+            .unwrap();
+    }
+
+    pub async fn add_pool(contract: &AMM, asset_pair: (AssetId, AssetId), pool: ContractId) {
+        contract
+            .methods()
+            .add_pool(
+                (
+                    ContractId::new(*asset_pair.0),
+                    ContractId::new(*asset_pair.1),
+                ),
+                pool,
+            )
+            .set_contracts(&[pool.into()])
+            .call()
+            .await
+            .unwrap();
+    }
+
+    pub async fn pool(contract: &AMM, asset_pair: (AssetId, AssetId)) -> Option<ContractId> {
+        contract
+            .methods()
+            .pool((
+                ContractId::new(*asset_pair.0),
+                ContractId::new(*asset_pair.1),
+            ))
+            .call()
+            .await
+            .unwrap()
+            .value
+    }
+}
+
+pub mod exchange {
+    use super::*;
+
+    pub async fn add_liquidity(
+        contract: &Exchange,
+        desired_liquidity: u64,
+        deadline: u64,
+        override_gas_limit: bool,
+    ) -> u64 {
+        let mut call_handler = contract
+            .methods()
+            .add_liquidity(desired_liquidity, deadline)
+            // `add_liquidity` adds liquidity by using up at least one of the assets
+            // one variable output is for the minted liquidity pool asset
+            // the other variable output is for the asset that is not used up
+            .append_variable_outputs(2);
+
+        if override_gas_limit {
+            let estimated_gas = call_handler
+                .estimate_transaction_cost(Some(GAS_TOLERANCE))
+                .await
+                .unwrap()
+                .gas_used;
+
+            call_handler =
+                call_handler.tx_params(TxParameters::new(None, Some(estimated_gas), None));
+        }
+
+        call_handler.call().await.unwrap().value
+    }
+
+    pub async fn constructor(contract: &Exchange, asset_pair: (AssetId, AssetId)) {
+        contract
+            .methods()
+            .constructor(
+                ContractId::new(*asset_pair.0),
+                ContractId::new(*asset_pair.1),
+            )
+            .call()
+            .await
+            .unwrap();
+    }
+
+    pub async fn deposit(contract: &Exchange, amount: u64, asset: AssetId) {
+        contract
+            .methods()
+            .deposit()
+            .call_params(CallParameters::new(Some(amount), Some(asset), None))
+            .call()
+            .await
+            .unwrap();
+    }
+
+    pub async fn remove_liquidity(
+        contract: &Exchange,
+        exchange_id: ContractId,
+        amount: u64,
+        min_asset_a: u64,
+        min_asset_b: u64,
+        deadline: u64,
+        override_gas_limit: bool,
+    ) -> RemoveLiquidityInfo {
+        let mut call_handler = contract
+            .methods()
+            .remove_liquidity(min_asset_a, min_asset_b, deadline)
+            .call_params(CallParameters::new(
+                Some(amount),
+                Some(AssetId::new(*exchange_id)),
+                None,
+            ))
+            .append_variable_outputs(2);
+
+        if override_gas_limit {
+            let estimated_gas = call_handler
+                .estimate_transaction_cost(Some(GAS_TOLERANCE))
+                .await
+                .unwrap()
+                .gas_used;
+
+            call_handler =
+                call_handler.tx_params(TxParameters::new(None, Some(estimated_gas), None));
+        }
+
+        call_handler.call().await.unwrap().value
+    }
+
+    pub async fn swap_exact_input(
+        contract: &Exchange,
+        input_asset: AssetId,
+        input_amount: u64,
+        min_output: Option<u64>,
+        deadline: u64,
+        override_gas_limit: bool,
+    ) -> u64 {
+        let mut call_handler = contract
+            .methods()
+            .swap_exact_input(min_output, deadline)
+            .call_params(CallParameters::new(
+                Some(input_amount),
+                Some(input_asset),
+                None,
+            ))
+            .append_variable_outputs(1);
+
+        if override_gas_limit {
+            let estimated_gas = call_handler
+                .estimate_transaction_cost(Some(GAS_TOLERANCE))
+                .await
+                .unwrap()
+                .gas_used;
+
+            call_handler =
+                call_handler.tx_params(TxParameters::new(None, Some(estimated_gas), None));
+        }
+
+        call_handler.call().await.unwrap().value
+    }
+
+    pub async fn swap_exact_output(
+        contract: &Exchange,
+        input_asset: AssetId,
+        input_amount: u64,
+        output: u64,
+        deadline: u64,
+        override_gas_limit: bool,
+    ) -> u64 {
+        let mut call_handler = contract
+            .methods()
+            .swap_exact_output(output, deadline)
+            .call_params(CallParameters::new(
+                Some(input_amount),
+                Some(input_asset),
+                None,
+            ))
+            .append_variable_outputs(2);
+
+        if override_gas_limit {
+            let estimated_gas = call_handler
+                .estimate_transaction_cost(Some(GAS_TOLERANCE))
+                .await
+                .unwrap()
+                .gas_used;
+
+            call_handler =
+                call_handler.tx_params(TxParameters::new(None, Some(estimated_gas), None));
+        }
+
+        call_handler.call().await.unwrap().value
+    }
+
+    pub async fn withdraw(contract: &Exchange, amount: u64, asset: AssetId) {
+        contract
+            .methods()
+            .withdraw(Asset {
+                id: ContractId::new(*asset),
+                amount,
+            })
+            .append_variable_outputs(1)
+            .call()
+            .await
+            .unwrap();
+    }
+
+    pub async fn balance(contract: &Exchange, asset: AssetId) -> u64 {
+        contract
+            .methods()
+            .balance(ContractId::new(*asset))
+            .call()
+            .await
+            .unwrap()
+            .value
+    }
+
+    pub async fn pool_info(contract: &Exchange) -> PoolInfo {
+        contract.methods().pool_info().call().await.unwrap().value
+    }
+
+    pub async fn preview_add_liquidity(
+        contract: &Exchange,
+        amount: u64,
+        asset: AssetId,
+        override_gas_limit: bool,
+    ) -> PreviewAddLiquidityInfo {
+        let mut call_handler = contract.methods().preview_add_liquidity(Asset {
+            id: ContractId::new(*asset),
+            amount,
+        });
+
+        if override_gas_limit {
+            let estimated_gas = call_handler
+                .estimate_transaction_cost(Some(GAS_TOLERANCE))
+                .await
+                .unwrap()
+                .gas_used;
+
+            call_handler =
+                call_handler.tx_params(TxParameters::new(None, Some(estimated_gas), None));
+        }
+
+        call_handler.call().await.unwrap().value
+    }
+
+    pub async fn preview_swap_exact_input(
+        contract: &Exchange,
+        exact_input: u64,
+        input_asset: AssetId,
+        override_gas_limit: bool,
+    ) -> PreviewSwapInfo {
+        let mut call_handler = contract.methods().preview_swap_exact_input(Asset {
+            id: ContractId::new(*input_asset),
+            amount: exact_input,
+        });
+
+        if override_gas_limit {
+            let estimated_gas = call_handler
+                .estimate_transaction_cost(Some(GAS_TOLERANCE))
+                .await
+                .unwrap()
+                .gas_used;
+
+            call_handler =
+                call_handler.tx_params(TxParameters::new(None, Some(estimated_gas), None));
+        }
+
+        call_handler.call().await.unwrap().value
+    }
+
+    pub async fn preview_swap_exact_output(
+        contract: &Exchange,
+        exact_output: u64,
+        output_asset: AssetId,
+        override_gas_limit: bool,
+    ) -> PreviewSwapInfo {
+        let mut call_handler = contract.methods().preview_swap_exact_output(Asset {
+            id: ContractId::new(*output_asset),
+            amount: exact_output,
+        });
+
+        if override_gas_limit {
+            let estimated_gas = call_handler
+                .estimate_transaction_cost(Some(GAS_TOLERANCE))
+                .await
+                .unwrap()
+                .gas_used;
+
+            call_handler =
+                call_handler.tx_params(TxParameters::new(None, Some(estimated_gas), None));
+        }
+
+        call_handler.call().await.unwrap().value
+    }
+}

--- a/AMM/project/test-utils/src/lib.rs
+++ b/AMM/project/test-utils/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod data_structures;
+pub mod interface;
+pub mod paths;
+pub mod setup;
+pub mod transaction;

--- a/AMM/project/test-utils/src/paths.rs
+++ b/AMM/project/test-utils/src/paths.rs
@@ -1,0 +1,15 @@
+pub const AMM_CONTRACT_BINARY_PATH: &str =
+    "../../contracts/AMM-contract/out/debug/AMM-contract.bin";
+pub const AMM_CONTRACT_STORAGE_PATH: &str =
+    "../../contracts/AMM-contract/out/debug/AMM-contract-storage_slots.json";
+pub const ATOMIC_ADD_LIQUIDITY_SCRIPT_BINARY_PATH: &str = "./out/debug/atomic-add-liquidity.bin";
+pub const EXCHANGE_CONTRACT_BINARY_PATH: &str =
+    "../../contracts/exchange-contract/out/debug/exchange-contract.bin";
+pub const EXCHANGE_CONTRACT_STORAGE_PATH: &str =
+    "../../contracts/exchange-contract/out/debug/exchange-contract-storage_slots.json";
+pub const MALICIOUS_EXCHANGE_CONTRACT_BINARY_PATH: &str =
+    "../exchange-contract/tests/artifacts/malicious-implementation/out/debug/malicious-implementation.bin";
+pub const MALICIOUS_EXCHANGE_CONTRACT_STORAGE_PATH: &str =
+    "../exchange-contract/tests/artifacts/malicious-implementation/out/debug/malicious-implementation-storage_slots.json";
+pub const SWAP_EXACT_INPUT_SCRIPT_BINARY_PATH: &str = "./out/debug/swap-exact-input.bin";
+pub const SWAP_EXACT_OUTPUT_SCRIPT_BINARY_PATH: &str = "./out/debug/swap-exact-output.bin";

--- a/AMM/project/test-utils/src/setup.rs
+++ b/AMM/project/test-utils/src/setup.rs
@@ -1,0 +1,281 @@
+use super::data_structures::{
+    AMMContract, ExchangeContract, ExchangeContractConfiguration, LiquidityParameters,
+};
+use fuels::{prelude::*, tx::Contract as TxContract};
+
+pub mod common {
+    use super::*;
+    use crate::{
+        data_structures::WalletAssetConfiguration,
+        interface::{
+            amm::initialize,
+            exchange::{add_liquidity, constructor, deposit},
+            Exchange, AMM,
+        },
+        paths::{
+            AMM_CONTRACT_BINARY_PATH, AMM_CONTRACT_STORAGE_PATH, EXCHANGE_CONTRACT_BINARY_PATH,
+            EXCHANGE_CONTRACT_STORAGE_PATH, MALICIOUS_EXCHANGE_CONTRACT_BINARY_PATH,
+            MALICIOUS_EXCHANGE_CONTRACT_STORAGE_PATH,
+        },
+    };
+    use std::collections::HashMap;
+
+    pub async fn deploy_amm(wallet: &WalletUnlocked) -> AMMContract {
+        let contract_id = Contract::deploy(
+            AMM_CONTRACT_BINARY_PATH,
+            &wallet,
+            TxParameters::default(),
+            StorageConfiguration {
+                storage_path: Some(AMM_CONTRACT_STORAGE_PATH.to_string()),
+                manual_storage_vec: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let instance = AMM::new(contract_id.clone(), wallet.clone());
+
+        AMMContract {
+            instance,
+            id: contract_id.into(),
+            pools: HashMap::new(),
+        }
+    }
+
+    pub async fn deploy_and_construct_exchange(
+        wallet: &WalletUnlocked,
+        config: &ExchangeContractConfiguration,
+    ) -> ExchangeContract {
+        let (id, instance) = deploy_exchange(&wallet, &config).await;
+
+        constructor(&instance, config.pair).await;
+
+        ExchangeContract {
+            bytecode_root: if config.compute_bytecode_root {
+                Some(exchange_bytecode_root().await)
+            } else {
+                None
+            },
+            id,
+            instance,
+            pair: config.pair,
+        }
+    }
+
+    pub async fn deploy_and_initialize_amm(wallet: &WalletUnlocked) -> AMMContract {
+        let amm = deploy_amm(&wallet).await;
+        initialize(&amm.instance, exchange_bytecode_root().await).await;
+        amm
+    }
+
+    pub async fn deploy_exchange(
+        wallet: &WalletUnlocked,
+        config: &ExchangeContractConfiguration,
+    ) -> (ContractId, Exchange) {
+        let binary_path = if config.malicious {
+            MALICIOUS_EXCHANGE_CONTRACT_BINARY_PATH
+        } else {
+            EXCHANGE_CONTRACT_BINARY_PATH
+        };
+        let storage_path = if config.malicious {
+            MALICIOUS_EXCHANGE_CONTRACT_STORAGE_PATH
+        } else {
+            EXCHANGE_CONTRACT_STORAGE_PATH
+        }
+        .to_string();
+
+        let contract_id = Contract::deploy_with_parameters(
+            binary_path,
+            &wallet,
+            TxParameters::default(),
+            StorageConfiguration {
+                storage_path: Some(storage_path),
+                manual_storage_vec: None,
+            },
+            Salt::from(config.salt),
+        )
+        .await
+        .unwrap();
+
+        let id = ContractId::from(contract_id.clone());
+        let instance = Exchange::new(contract_id, wallet.clone());
+
+        (id, instance)
+    }
+
+    // TODO: once the script is reliable enough, use it for this functionality
+    pub async fn deposit_and_add_liquidity(
+        liquidity_parameters: &LiquidityParameters,
+        exchange: &ExchangeContract,
+        override_gas_limit: bool,
+    ) -> u64 {
+        deposit(
+            &exchange.instance,
+            liquidity_parameters.amounts.0,
+            exchange.pair.0,
+        )
+        .await;
+
+        deposit(
+            &exchange.instance,
+            liquidity_parameters.amounts.1,
+            exchange.pair.1,
+        )
+        .await;
+
+        add_liquidity(
+            &exchange.instance,
+            liquidity_parameters.liquidity,
+            liquidity_parameters.deadline,
+            override_gas_limit,
+        )
+        .await
+    }
+
+    pub async fn exchange_bytecode_root() -> ContractId {
+        let exchange_raw_code = Contract::load_contract(
+            EXCHANGE_CONTRACT_BINARY_PATH,
+            &StorageConfiguration::default().storage_path,
+        )
+        .unwrap()
+        .raw;
+        (*TxContract::root_from_code(exchange_raw_code)).into()
+    }
+
+    pub async fn setup_wallet_and_provider(
+        asset_parameters: &WalletAssetConfiguration,
+    ) -> (WalletUnlocked, Vec<AssetId>, Provider) {
+        let mut wallet = WalletUnlocked::new_random(None);
+
+        let (coins, asset_ids) = setup_multiple_assets_coins(
+            wallet.address(),
+            asset_parameters.number_of_assets,
+            asset_parameters.coins_per_asset,
+            asset_parameters.amount_per_coin,
+        );
+
+        let (provider, _socket_addr) = setup_test_provider(coins.clone(), vec![], None, None).await;
+
+        wallet.set_provider(provider.clone());
+
+        (wallet, asset_ids, provider)
+    }
+}
+
+pub mod scripts {
+    use super::*;
+    use crate::{
+        data_structures::TransactionParameters,
+        interface::amm::add_pool,
+        transaction::{
+            transaction_input_coin, transaction_input_contract, transaction_output_contract,
+            transaction_output_variable,
+        },
+    };
+    use common::{deploy_and_construct_exchange, deposit_and_add_liquidity};
+    use fuels::tx::{Input, Output};
+
+    pub const MAXIMUM_INPUT_AMOUNT: u64 = 1_000_000;
+
+    pub async fn setup_exchange_contract(
+        wallet: &WalletUnlocked,
+        exchange_config: &ExchangeContractConfiguration,
+        liquidity_parameters: &LiquidityParameters,
+    ) -> ExchangeContract {
+        let exchange = deploy_and_construct_exchange(&wallet, &exchange_config).await;
+
+        deposit_and_add_liquidity(&liquidity_parameters, &exchange, false).await;
+
+        exchange
+    }
+
+    pub async fn setup_exchange_contracts(
+        wallet: &WalletUnlocked,
+        provider: &Provider,
+        amm: &mut AMMContract,
+        asset_ids: &Vec<AssetId>,
+    ) -> () {
+        let mut exchange_index = 0;
+
+        while exchange_index < asset_ids.len() - 1 {
+            // set exchanges so that there are pools for
+            // (asset 1, asset 2), (asset 2, asset 3), (asset 3, asset 4) and so on
+            let asset_pair = (
+                *asset_ids.get(exchange_index).unwrap(),
+                *asset_ids.get(exchange_index + 1).unwrap(),
+            );
+
+            let exchange = setup_exchange_contract(
+                wallet,
+                &ExchangeContractConfiguration::new(
+                    Some(asset_pair),
+                    None,
+                    None,
+                    // deploy identical contracts for different pools with salt
+                    Some([(exchange_index as u8); 32]),
+                ),
+                &LiquidityParameters::new(
+                    // add initial liquidity to exchanges to have ratios such as
+                    // 1:1, 1:2, 1:3 and so on
+                    Some((100_000, 100_000 * (exchange_index as u64 + 1))),
+                    // a reasonable deadline for adding liquidity
+                    Some(provider.latest_block_height().await.unwrap() + 10),
+                    // liquidity that will be added is greater than or equal to the lowest deposit
+                    Some(100_000),
+                ),
+            )
+            .await;
+
+            add_pool(&amm.instance, asset_pair, exchange.id).await;
+
+            amm.pools.insert(asset_pair, exchange);
+            exchange_index += 1;
+        }
+    }
+
+    pub async fn transaction_inputs_outputs(
+        wallet: &WalletUnlocked,
+        provider: &Provider,
+        contracts: &Vec<ContractId>,
+        assets: &Vec<AssetId>,
+        amounts: Option<&Vec<u64>>,
+    ) -> TransactionParameters {
+        let mut input_contracts: Vec<Input> = Vec::with_capacity(contracts.len());
+        let mut output_contracts: Vec<Output> = Vec::with_capacity(contracts.len());
+
+        contracts
+            .into_iter()
+            .enumerate()
+            .for_each(|(index, contract_id)| {
+                input_contracts.push(transaction_input_contract(*contract_id));
+                output_contracts.push(transaction_output_contract(index as u8));
+            });
+
+        let mut input_coins: Vec<Input> = vec![]; // capacity depends on wallet resources
+        let mut output_variables: Vec<Output> = Vec::with_capacity(assets.len());
+
+        let mut asset_index = 0;
+        while asset_index < assets.len() {
+            input_coins.extend(
+                transaction_input_coin(
+                    &provider,
+                    wallet.address(),
+                    *assets.get(asset_index).unwrap(),
+                    if amounts.is_some() {
+                        *amounts.unwrap().get(asset_index).unwrap()
+                    } else {
+                        MAXIMUM_INPUT_AMOUNT
+                    },
+                )
+                .await,
+            );
+            output_variables.push(transaction_output_variable());
+            asset_index += 1;
+        }
+
+        TransactionParameters {
+            inputs: [input_contracts, input_coins].concat(),
+            outputs: [output_contracts, output_variables].concat(),
+        }
+    }
+}

--- a/AMM/project/test-utils/src/transaction.rs
+++ b/AMM/project/test-utils/src/transaction.rs
@@ -1,0 +1,64 @@
+use fuels::{
+    prelude::*,
+    tx::{Bytes32, Input, Output, TxPointer, UtxoId},
+    types::resource::Resource,
+};
+
+pub async fn transaction_input_coin(
+    provider: &Provider,
+    from: &Bech32Address,
+    asset_id: AssetId,
+    amount: u64,
+) -> Vec<Input> {
+    let coins = &provider
+        .get_spendable_resources(from, asset_id, amount)
+        .await
+        .unwrap();
+
+    let input_coins: Vec<Input> = coins
+        .into_iter()
+        .map(|coin| {
+            let (coin_utxo_id, coin_amount) = match coin {
+                Resource::Coin(coin) => (coin.utxo_id.clone(), coin.amount.clone()),
+                _ => panic!("Resource type does not match"),
+            };
+            Input::CoinSigned {
+                utxo_id: coin_utxo_id.into(),
+                owner: Address::from(from),
+                amount: coin_amount.into(),
+                asset_id: asset_id,
+                tx_pointer: TxPointer::default(),
+                witness_index: 0,
+                maturity: 0,
+            }
+        })
+        .collect();
+
+    input_coins
+}
+
+pub fn transaction_input_contract(contract_id: ContractId) -> Input {
+    Input::Contract {
+        utxo_id: UtxoId::new(Bytes32::zeroed(), 0),
+        balance_root: Bytes32::zeroed(),
+        state_root: Bytes32::zeroed(),
+        tx_pointer: TxPointer::default(),
+        contract_id,
+    }
+}
+
+pub fn transaction_output_contract(input_index: u8) -> Output {
+    Output::Contract {
+        input_index,
+        balance_root: Bytes32::zeroed(),
+        state_root: Bytes32::zeroed(),
+    }
+}
+
+pub fn transaction_output_variable() -> Output {
+    Output::Variable {
+        amount: 0,
+        to: Address::zeroed(),
+        asset_id: AssetId::default(),
+    }
+}


### PR DESCRIPTION
## Type of change

- New feature

## Changes

- Swap exact input and swap exact output scripts
- Atomic deposit and add liquidity script
- Test utils module
- Tests for scripts

## Notes

Before merging to master:
- Script tests for revert cases should have the actual error messages instead of `#[should_panic(expected = "Revert(18446744073709486080)")]` once [feat: support logs from external contracts](https://github.com/FuelLabs/fuels-rs/pull/762) is merged
- `fuels` dependencies should be changed to version instead of master branch once new version is out
- `exchange-contract/utils/multiply_divide` function should be renamed to something along the lines of "proportions"

After merging to master: 
- The application progress on Notion will be updated

## Related Issues

Closes #229
Closes #287
