### PR TITLE
changed - to * refs #392

### DIFF
--- a/.template/project/template-contract/src/interface.sw
+++ b/.template/project/template-contract/src/interface.sw
@@ -5,10 +5,10 @@ abi Template {
     ///
     /// # Arguments
     ///
-    /// - `<argument>`: <description>
+    /// * `<argument>`: <description>
     ///
     /// # Reverts
     ///
-    /// - <condition>
+    /// * <condition>
     fn template();
 }


### PR DESCRIPTION
## Type of change

- New feature

## Changes

The following changes have been made:

- For bullets `-` changed to `*`

## Notes


## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #392 
