### PR TITLE
AMM: Remove `ExpectedZeroAmount` error and relevant test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ concurrency:
 
 env:
   REGISTRY: ghcr.io
-  RUST_VERSION: 1.66.0
+  RUST_VERSION: 1.67.0
   FORC_VERSION: 0.33.1
   CORE_VERSION: 0.15.3
   PATH_TO_SCRIPTS: .github/scripts

--- a/AMM/README.md
+++ b/AMM/README.md
@@ -12,8 +12,8 @@
     <a href="https://crates.io/crates/fuel-core/0.15.3" alt="fuel-core">
         <img src="https://img.shields.io/badge/fuel--core-v0.15.3-yellow" />
     </a>
-    <a href="https://crates.io/crates/fuels/0.34.0" alt="forc">
-        <img src="https://img.shields.io/badge/fuels-v0.34.0-blue" />
+    <a href="https://crates.io/crates/fuels/0.36.0" alt="forc">
+        <img src="https://img.shields.io/badge/fuels-v0.36.0-blue" />
     </a>
 </p>
 

--- a/AMM/project/contracts/AMM-contract/Cargo.toml
+++ b/AMM/project/contracts/AMM-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.34.0", features = ["fuel-core-lib"] }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 

--- a/AMM/project/contracts/AMM-contract/Cargo.toml
+++ b/AMM/project/contracts/AMM-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+fuels = { version = "0.36.0", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 

--- a/AMM/project/contracts/exchange-contract/Cargo.toml
+++ b/AMM/project/contracts/exchange-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.34.0", features = ["fuel-core-lib"] }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 

--- a/AMM/project/contracts/exchange-contract/Cargo.toml
+++ b/AMM/project/contracts/exchange-contract/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+fuels = { version = "0.36.0", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.21.0", features = ["rt", "macros"] }
 

--- a/AMM/project/contracts/exchange-contract/src/errors.sw
+++ b/AMM/project/contracts/exchange-contract/src/errors.sw
@@ -11,7 +11,6 @@ pub enum InputError {
     DeadlinePassed: u64,
     ExpectedNonZeroAmount: ContractId,
     ExpectedNonZeroParameter: ContractId,
-    ExpectedZeroAmount: (),
     InvalidAsset: (),
 }
 

--- a/AMM/project/contracts/exchange-contract/src/main.sw
+++ b/AMM/project/contracts/exchange-contract/src/main.sw
@@ -61,7 +61,6 @@ impl Exchange for Contract {
     fn add_liquidity(desired_liquidity: u64, deadline: u64) -> u64 {
         require(storage.pair.is_some(), InitError::AssetPairNotSet);
         require(deadline > height(), InputError::DeadlinePassed(deadline));
-        require(msg_amount() == 0, InputError::ExpectedZeroAmount);
         require(MINIMUM_LIQUIDITY <= desired_liquidity, InputError::CannotAddLessThanMinimumLiquidity(desired_liquidity));
 
         let sender = msg_sender().unwrap();

--- a/AMM/project/contracts/exchange-contract/tests/functions/add_liquidity.rs
+++ b/AMM/project/contracts/exchange-contract/tests/functions/add_liquidity.rs
@@ -237,7 +237,6 @@ mod success {
 mod revert {
     use super::*;
     use crate::utils::setup;
-    use fuels::prelude::CallParameters;
 
     #[tokio::test]
     #[should_panic(expected = "AssetPairNotSet")]
@@ -265,29 +264,6 @@ mod revert {
         );
 
         deposit_and_add_liquidity(&override_liquidity_parameters, &exchange, false).await;
-    }
-
-    #[tokio::test]
-    #[should_panic(expected = "ExpectedZeroAmount")]
-    async fn when_msg_amount_is_not_zero() {
-        let (exchange, _wallet, liquidity_parameters, _asset_c_id) =
-            setup_and_construct(true, false).await;
-
-        exchange
-            .instance
-            .methods()
-            .add_liquidity(
-                liquidity_parameters.liquidity,
-                liquidity_parameters.deadline,
-            )
-            // `add_liquidity` adds liquidity by using up at least one of the assets
-            // one variable output is for the minted liquidity pool asset
-            // the other variable output is for the asset that is not used up
-            .append_variable_outputs(2)
-            .call_params(CallParameters::new(Some(1), None, None))
-            .call()
-            .await
-            .unwrap();
     }
 
     #[tokio::test]

--- a/AMM/project/scripts/atomic-add-liquidity/Cargo.toml
+++ b/AMM/project/scripts/atomic-add-liquidity/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+fuels = { version = "0.36.0", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/AMM/project/scripts/atomic-add-liquidity/Cargo.toml
+++ b/AMM/project/scripts/atomic-add-liquidity/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.34.0", features = ["fuel-core-lib"] }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/AMM/project/scripts/swap-exact-input/Cargo.toml
+++ b/AMM/project/scripts/swap-exact-input/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+fuels = { version = "0.36.0", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/AMM/project/scripts/swap-exact-input/Cargo.toml
+++ b/AMM/project/scripts/swap-exact-input/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.34.0", features = ["fuel-core-lib"] }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/AMM/project/scripts/swap-exact-output/Cargo.toml
+++ b/AMM/project/scripts/swap-exact-output/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+fuels = { version = "0.36.0", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/AMM/project/scripts/swap-exact-output/Cargo.toml
+++ b/AMM/project/scripts/swap-exact-output/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dev-dependencies]
-fuels = { version = "0.34.0", features = ["fuel-core-lib"] }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
 test-utils = { path = "../../test-utils" }
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/AMM/project/test-utils/Cargo.toml
+++ b/AMM/project/test-utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
+fuels = { version = "0.36.0", features = ["fuel-core-lib"] }
 
 [lib]
 doctest = false

--- a/AMM/project/test-utils/Cargo.toml
+++ b/AMM/project/test-utils/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 license = "Apache-2.0"
 
 [dependencies]
-fuels = { version = "0.34.0", features = ["fuel-core-lib"] }
+fuels = { git = "https://github.com/FuelLabs/fuels-rs.git", features = ["fuel-core-lib"] }
 
 [lib]
 doctest = false

--- a/AMM/project/test-utils/src/interface.rs
+++ b/AMM/project/test-utils/src/interface.rs
@@ -116,6 +116,7 @@ pub mod exchange {
             .methods()
             .deposit()
             .call_params(CallParameters::new(Some(amount), Some(asset), None))
+            .unwrap()
             .call()
             .await
             .unwrap();
@@ -138,6 +139,7 @@ pub mod exchange {
                 Some(AssetId::new(*exchange_id)),
                 None,
             ))
+            .unwrap()
             .append_variable_outputs(2);
 
         if override_gas_limit {
@@ -170,6 +172,7 @@ pub mod exchange {
                 Some(input_asset),
                 None,
             ))
+            .unwrap()
             .append_variable_outputs(1);
 
         if override_gas_limit {
@@ -202,6 +205,7 @@ pub mod exchange {
                 Some(input_asset),
                 None,
             ))
+            .unwrap()
             .append_variable_outputs(2);
 
         if override_gas_limit {

--- a/AMM/project/test-utils/src/setup.rs
+++ b/AMM/project/test-utils/src/setup.rs
@@ -167,7 +167,6 @@ pub mod scripts {
     use crate::{data_structures::TransactionParameters, interface::amm::add_pool};
     use common::{deploy_and_construct_exchange, deposit_and_add_liquidity};
     use fuels::{
-        programs::contract::SettableContract,
         tx::{Input, Output, TxPointer},
         types::resource::Resource,
     };


### PR DESCRIPTION
## Type of change

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- `ExpectedZeroAmount` error, the relevant `require` and its test have been removed since the method does not have a `payable` annotation.
- AMM `fuels 0.34.0` -> `fuels 0.36.0`
- CI `rust 1.66.0` -> `rust 1.67.0` because previous version is not compatible with `fuels 0.36.0`

## Related Issues

Closes #374 
