### PR TITLE
Factor out apps in `.devops` scripts into a single location

### DIFF
--- a/.devops/apps.txt
+++ b/.devops/apps.txt
@@ -1,0 +1,14 @@
+AMM
+DAO
+NFT
+OTC-swap-predicate
+airdrop
+auctions/english-auction
+escrow
+fractional-NFT
+fundraiser
+games/TicTacToe
+multisig-wallet
+name-registry
+oracle
+timelock

--- a/.devops/build.sh
+++ b/.devops/build.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-APPS=("AMM" "DAO" "NFT" "OTC-swap-predicate" "airdrop" "auctions/english-auction" "escrow" "fractional-NFT" "fundraiser" "games/TicTacToe" "multisig-wallet" "name-registry" "oracle" "timelock")
+declare -a APPS
+mapfile -t APPS < apps.txt
+
 errors=()
 
 REPO_ROOT=$(dirname $(dirname $(realpath $0)))

--- a/.devops/bump_toolchain.sh
+++ b/.devops/bump_toolchain.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-APPS=("AMM" "DAO" "NFT" "OTC-swap-predicate" "airdrop" "auctions" "escrow" "fractional-NFT" "fundraiser" "games/TicTacToe" "multisig-wallet" "name-registry" "oracle" "timelock")
+declare -a APPS
+mapfile -t APPS < apps.txt
+
 errors=()
 success=()
 

--- a/.devops/test.sh
+++ b/.devops/test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-APPS=("AMM" "DAO" "NFT" "OTC-swap-predicate" "airdrop" "auctions/english-auction" "escrow" "fractional-NFT" "fundraiser" "games/TicTacToe" "multisig-wallet" "name-registry" "oracle" "timelock")
+declare -a APPS
+mapfile -t APPS < apps.txt
+
 errors=()
 
 REPO_ROOT=$(dirname $(dirname $(realpath $0)))


### PR DESCRIPTION
## Type of change

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- apps are in a single file `apps.txt` and in the order that you read them from top to bottom when looking at the repo
- loading the apps in each devops script

## Related Issues

Closes #468 
