### PR TITLE
`.devops` script to format sway and rust code

### DIFF
--- a/.devops/format.sh
+++ b/.devops/format.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+declare -a APPS
+mapfile -t APPS < apps.txt
+
+REPO_ROOT=$(dirname $(dirname $(realpath $0)))
+
+cd $REPO_ROOT
+
+for app in "${APPS[@]}"
+do
+    echo Formatting $app
+    cd $app/project
+    forc fmt
+    cargo fmt
+    cd $REPO_ROOT
+    echo
+done


### PR DESCRIPTION
## Type of change

- New feature

## Changes

The following changes have been made:

- New script to run `forc fmt` and then `cargo fmt` inside each `/app/project`

## Notes

- No error reporting at the end because `forc fmt` returns a 0 error code instead of non-zero when it errors out.
- Cargo errors out correctly so to keep it consistent we don't report both

## Related Issues

Closes #553 
