### PR TITLE
OTC: change fuels::prelude::* to be explicit #439

### DIFF
--- a/OTC-swap-predicate/project/predicates/swap-predicate/tests/harness.rs
+++ b/OTC-swap-predicate/project/predicates/swap-predicate/tests/harness.rs
@@ -1,6 +1,6 @@
 mod utils;
 
-use fuels::prelude::*;
+use fuels::prelude::AssetId;
 
 // These constants should match those hard-coded in the predicate
 const ASK_AMOUNT: u64 = 42;


### PR DESCRIPTION
## Type of change

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)


## Changes

The following changes have been made:

- Change 1 : Changed prelude import to be explicit, closes#439


## Related Issues


Closes #439
