### PR TITLE
Add cname to swayapps book

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -29,4 +29,5 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./.docs/contributing-book/book
           destination_dir: book
+          cname: swayapps.fuel.network
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
## Type of change

Adds a cname to make the sway applications docs navigable from swayapps.fuel.network
