### PR TITLE
Multisig: change optional data fields to be mandatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: rustup component add rustfmt
 
       - name: Install Fuel toolchain
-        uses: FuelLabs/action-fuel-toolchain@v0.4.0
+        uses: FuelLabs/action-fuel-toolchain@v0.6.0
         with:
           toolchain: latest
           date: 2023-02-16
@@ -125,7 +125,7 @@ jobs:
         run: rustup component add rustfmt
 
       - name: Install Fuel toolchain
-        uses: FuelLabs/action-fuel-toolchain@v0.4.0
+        uses: FuelLabs/action-fuel-toolchain@v0.6.0
         with:
           toolchain: latest
           date: 2023-01-18

--- a/multisig-wallet/project/contracts/multisig-contract/src/data_structures/hashing.sw
+++ b/multisig-wallet/project/contracts/multisig-contract/src/data_structures/hashing.sw
@@ -23,7 +23,7 @@ pub struct Threshold {
     /// instance of the multisig.
     contract_identifier: ContractId,
     /// Payload sent to destination  // TODO: change to Bytes when SDK support is implemented: https://github.com/FuelLabs/fuels-rs/issues/723
-    data: Option<b256>,
+    data: b256,
     /// Value used to prevent double spending.
     nonce: u64,
     /// The number of approvals required to enable a transaction to be sent.
@@ -35,7 +35,7 @@ pub struct Weight {
     /// instance of the multisig.
     contract_identifier: ContractId,
     /// Payload sent to destination  // TODO: change to Bytes when SDK support is implemented: https://github.com/FuelLabs/fuels-rs/issues/723
-    data: Option<b256>,
+    data: b256,
     /// Value used to prevent double spending.
     nonce: u64,
     /// The user of the multisig, who can sign transactions to add their approval.

--- a/multisig-wallet/project/contracts/multisig-contract/src/interface.sw
+++ b/multisig-wallet/project/contracts/multisig-contract/src/interface.sw
@@ -66,7 +66,7 @@ abi MultiSignatureWallet {
     /// * When the recovered addresses are not in ascending order (0x1 < 0x2 < 0x3...).
     /// * When the total approval count is less than the required threshold for execution.
     #[storage(read, write)]
-    fn set_threshold(data: Option<b256>, signatures: Vec<SignatureInfo>, threshold: u64);
+    fn set_threshold(data: b256, signatures: Vec<SignatureInfo>, threshold: u64);
 
     /// Changes the approval weights of a user in the contract.
     ///
@@ -83,7 +83,7 @@ abi MultiSignatureWallet {
     /// * When the recovered addresses are not in ascending order (0x1 < 0x2 < 0x3...).
     /// * When the total approval count is less than the required threshold for execution.
     #[storage(read, write)]
-    fn set_weight(data: Option<b256>, signatures: Vec<SignatureInfo>, user: User);
+    fn set_weight(data: b256, signatures: Vec<SignatureInfo>, user: User);
 
     /// Transfers assets to outputs & contracts if the signatures meet the threshold requirement.
     ///
@@ -147,7 +147,7 @@ abi Info {
     /// * `data` - The data field of the transaction.
     /// * `nonce` - The nonce field of the transaction.
     /// * `threshold` - The number of approvals required to enable a transaction to be sent.
-    fn threshold_hash(data: Option<b256>, nonce: u64, threshold: u64) -> b256;
+    fn threshold_hash(data: b256, nonce: u64, threshold: u64) -> b256;
 
     /// Creates a hash which is used to make updates to the weight of a user.
     ///
@@ -156,5 +156,5 @@ abi Info {
     /// * `data` - The data field of the transaction.
     /// * `nonce` - The nonce field of the transaction.
     /// * `user` - The user of the multisig, who can sign transactions to add their approval.
-    fn weight_hash(data: Option<b256>, nonce: u64, user: User) -> b256;
+    fn weight_hash(data: b256, nonce: u64, user: User) -> b256;
 }

--- a/multisig-wallet/project/contracts/multisig-contract/src/main.sw
+++ b/multisig-wallet/project/contracts/multisig-contract/src/main.sw
@@ -94,11 +94,7 @@ impl MultiSignatureWallet for Contract {
     }
 
     #[storage(read, write)]
-    fn set_threshold(
-        data: Option<b256>,
-        signatures: Vec<SignatureInfo>,
-        threshold: u64,
-    ) {
+    fn set_threshold(data: b256, signatures: Vec<SignatureInfo>, threshold: u64) {
         require(storage.nonce != 0, InitError::NotInitialized);
         require(threshold != 0, InitError::ThresholdCannotBeZero);
         require(threshold <= storage.total_weight, InitError::TotalWeightCannotBeLessThanThreshold);
@@ -120,11 +116,7 @@ impl MultiSignatureWallet for Contract {
     }
 
     #[storage(read, write)]
-    fn set_weight(
-        data: Option<b256>,
-        signatures: Vec<SignatureInfo>,
-        user: User,
-    ) {
+    fn set_weight(data: b256, signatures: Vec<SignatureInfo>, user: User) {
         require(storage.nonce != 0, InitError::NotInitialized);
 
         let transaction_hash = hash_weight(data, storage.nonce, user);
@@ -201,11 +193,11 @@ impl Info for Contract {
         hash_transaction(data, nonce, to, value)
     }
 
-    fn threshold_hash(data: Option<b256>, nonce: u64, threshold: u64) -> b256 {
+    fn threshold_hash(data: b256, nonce: u64, threshold: u64) -> b256 {
         hash_threshold(data, nonce, threshold)
     }
 
-    fn weight_hash(data: Option<b256>, nonce: u64, user: User) -> b256 {
+    fn weight_hash(data: b256, nonce: u64, user: User) -> b256 {
         hash_weight(data, nonce, user)
     }
 }

--- a/multisig-wallet/project/contracts/multisig-contract/src/utils.sw
+++ b/multisig-wallet/project/contracts/multisig-contract/src/utils.sw
@@ -34,7 +34,7 @@ pub fn hash_transaction(data: b256, nonce: u64, to: Identity, value: u64) -> b25
 }
 
 /// Takes in transaction data and hashes it into a unique transaction hash.
-pub fn hash_threshold(data: Option<b256>, nonce: u64, threshold: u64) -> b256 {
+pub fn hash_threshold(data: b256, nonce: u64, threshold: u64) -> b256 {
     sha256(Threshold {
         contract_identifier: contract_id(),
         data,
@@ -44,7 +44,7 @@ pub fn hash_threshold(data: Option<b256>, nonce: u64, threshold: u64) -> b256 {
 }
 
 /// Takes in transaction data and hashes it into a unique transaction hash.
-pub fn hash_weight(data: Option<b256>, nonce: u64, user: User) -> b256 {
+pub fn hash_weight(data: b256, nonce: u64, user: User) -> b256 {
     sha256(Weight {
         contract_identifier: contract_id(),
         data,

--- a/multisig-wallet/project/contracts/multisig-contract/tests/functions/core/set_threshold.rs
+++ b/multisig-wallet/project/contracts/multisig-contract/tests/functions/core/set_threshold.rs
@@ -3,7 +3,10 @@ use crate::utils::{
         core::{constructor, set_threshold},
         info::{nonce, threshold, threshold_hash},
     },
-    setup::{default_users, setup_env, transfer_signatures, DEFAULT_THRESHOLD, VALID_SIGNER_PK},
+    setup::{
+        default_users, setup_env, transfer_parameters, transfer_signatures, DEFAULT_THRESHOLD,
+        VALID_SIGNER_PK,
+    },
 };
 use fuels::{signers::fuel_crypto::Message, types::Bits256};
 
@@ -15,6 +18,7 @@ mod success {
     #[tokio::test]
     async fn sets_the_threshold() {
         let (private_key, deployer, _non_owner) = setup_env(VALID_SIGNER_PK).await.unwrap();
+        let (_receiver_wallet, _receiver, data) = transfer_parameters();
 
         constructor(&deployer.contract, default_users()).await;
 
@@ -23,7 +27,7 @@ mod success {
 
         let tx_hash = threshold_hash(
             &deployer.contract,
-            None,
+            data.clone(),
             initial_nonce,
             previous_threshold - 1,
         )
@@ -34,7 +38,7 @@ mod success {
         let signatures = transfer_signatures(private_key, tx_hash).await;
 
         let response =
-            set_threshold(&deployer.contract, None, signatures, DEFAULT_THRESHOLD - 1).await;
+            set_threshold(&deployer.contract, data, signatures, DEFAULT_THRESHOLD - 1).await;
 
         let final_nonce = nonce(&deployer.contract).await.value;
         let threshold = threshold(&deployer.contract).await.value;
@@ -63,61 +67,79 @@ mod revert {
     #[should_panic(expected = "NotInitialized")]
     async fn not_initialized() {
         let (private_key, deployer, _non_owner) = setup_env(VALID_SIGNER_PK).await.unwrap();
+        let (_receiver_wallet, _receiver, data) = transfer_parameters();
 
         let initial_nonce = nonce(&deployer.contract).await.value;
         let previous_threshold = threshold(&deployer.contract).await.value;
 
-        let tx_hash = threshold_hash(&deployer.contract, None, initial_nonce, previous_threshold)
-            .await
-            .value
-            .0;
+        let tx_hash = threshold_hash(
+            &deployer.contract,
+            data.clone(),
+            initial_nonce,
+            previous_threshold,
+        )
+        .await
+        .value
+        .0;
 
         let tx_hash = unsafe { Message::from_bytes_unchecked(tx_hash) };
         let signatures = transfer_signatures(private_key, tx_hash).await;
 
-        set_threshold(&deployer.contract, None, signatures, DEFAULT_THRESHOLD).await;
+        set_threshold(&deployer.contract, data, signatures, DEFAULT_THRESHOLD).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "ThresholdCannotBeZero")]
     async fn when_threshold_is_zero() {
         let (private_key, deployer, _non_owner) = setup_env(VALID_SIGNER_PK).await.unwrap();
+        let (_receiver_wallet, _receiver, data) = transfer_parameters();
 
         constructor(&deployer.contract, default_users()).await;
 
         let initial_nonce = nonce(&deployer.contract).await.value;
         let new_threshold = 0;
 
-        let tx_hash = threshold_hash(&deployer.contract, None, initial_nonce, new_threshold)
-            .await
-            .value
-            .0;
+        let tx_hash = threshold_hash(
+            &deployer.contract,
+            data.clone(),
+            initial_nonce,
+            new_threshold,
+        )
+        .await
+        .value
+        .0;
 
         let tx_hash = unsafe { Message::from_bytes_unchecked(tx_hash) };
         let signatures = transfer_signatures(private_key, tx_hash).await;
 
-        set_threshold(&deployer.contract, None, signatures, new_threshold).await;
+        set_threshold(&deployer.contract, data, signatures, new_threshold).await;
     }
 
     #[tokio::test]
     #[should_panic(expected = "TotalWeightCannotBeLessThanThreshold")]
     async fn when_threshold_is_greater_than_approval_weight_of_all_owners() {
         let (private_key, deployer, _non_owner) = setup_env(VALID_SIGNER_PK).await.unwrap();
+        let (_receiver_wallet, _receiver, data) = transfer_parameters();
 
         constructor(&deployer.contract, default_users()).await;
 
         let initial_nonce = nonce(&deployer.contract).await.value;
         let previous_threshold = threshold(&deployer.contract).await.value;
 
-        let tx_hash = threshold_hash(&deployer.contract, None, initial_nonce, previous_threshold)
-            .await
-            .value
-            .0;
+        let tx_hash = threshold_hash(
+            &deployer.contract,
+            data.clone(),
+            initial_nonce,
+            previous_threshold,
+        )
+        .await
+        .value
+        .0;
 
         let tx_hash = unsafe { Message::from_bytes_unchecked(tx_hash) };
         let signatures = transfer_signatures(private_key, tx_hash).await;
 
-        set_threshold(&deployer.contract, None, signatures, DEFAULT_THRESHOLD + 1).await;
+        set_threshold(&deployer.contract, data, signatures, DEFAULT_THRESHOLD + 1).await;
     }
 
     #[tokio::test]
@@ -133,7 +155,7 @@ mod revert {
 
         let tx_hash = threshold_hash(
             &deployer.contract,
-            Some(data),
+            data.clone(),
             initial_nonce,
             previous_threshold - 1,
         )
@@ -145,12 +167,6 @@ mod revert {
         let mut signatures = transfer_signatures(private_key, tx_hash).await;
         signatures.pop();
 
-        set_threshold(
-            &deployer.contract,
-            Some(data),
-            signatures,
-            DEFAULT_THRESHOLD - 1,
-        )
-        .await;
+        set_threshold(&deployer.contract, data, signatures, DEFAULT_THRESHOLD - 1).await;
     }
 }

--- a/multisig-wallet/project/contracts/multisig-contract/tests/functions/info/threshold_hash.rs
+++ b/multisig-wallet/project/contracts/multisig-contract/tests/functions/info/threshold_hash.rs
@@ -15,7 +15,7 @@ mod success {
 
     struct Threshold {
         contract_identifier: ContractId,
-        data: Option<Bits256>,
+        data: Bits256,
         nonce: u64,
         threshold: u64,
     }
@@ -33,7 +33,7 @@ mod success {
         // Recreate Threshold instance
         let tx = Threshold {
             contract_identifier: deployer.contract.get_contract_id().try_into().unwrap(),
-            data: Some(data),
+            data: data,
             nonce,
             threshold,
         };
@@ -48,7 +48,7 @@ mod success {
         let encoded_tx_struct = ABIEncoder::encode(&vec![tx_token]).unwrap().resolve(0);
         let expected_hash = Hasher::hash(encoded_tx_struct);
 
-        let response = threshold_hash(&deployer.contract, Some(data), nonce, threshold)
+        let response = threshold_hash(&deployer.contract, data, nonce, threshold)
             .await
             .value;
 

--- a/multisig-wallet/project/contracts/multisig-contract/tests/functions/info/weight_hash.rs
+++ b/multisig-wallet/project/contracts/multisig-contract/tests/functions/info/weight_hash.rs
@@ -15,7 +15,7 @@ mod success {
 
     struct Weight {
         contract_identifier: ContractId,
-        data: Option<Bits256>,
+        data: Bits256,
         nonce: u64,
         user: User,
     }
@@ -33,7 +33,7 @@ mod success {
         // Recreate Weight instance
         let tx = Weight {
             contract_identifier: deployer.contract.get_contract_id().try_into().unwrap(),
-            data: Some(data),
+            data,
             nonce,
             user: user.clone(),
         };
@@ -48,7 +48,7 @@ mod success {
         let encoded_tx_struct = ABIEncoder::encode(&vec![tx_token]).unwrap().resolve(0);
         let expected_hash = Hasher::hash(encoded_tx_struct);
 
-        let response = weight_hash(&deployer.contract, Some(data), nonce, user)
+        let response = weight_hash(&deployer.contract, data, nonce, user)
             .await
             .value;
 

--- a/multisig-wallet/project/contracts/multisig-contract/tests/utils/interface/core.rs
+++ b/multisig-wallet/project/contracts/multisig-contract/tests/utils/interface/core.rs
@@ -37,7 +37,7 @@ pub async fn execute_transaction(
 
 pub async fn set_threshold(
     contract: &MultiSig,
-    data: Option<Bits256>,
+    data: Bits256,
     signatures_data: Vec<SignatureInfo>,
     threshold: u64,
 ) -> FuelCallResponse<()> {
@@ -51,7 +51,7 @@ pub async fn set_threshold(
 
 pub async fn set_weight(
     contract: &MultiSig,
-    data: Option<Bits256>,
+    data: Bits256,
     signatures_data: Vec<SignatureInfo>,
     user: User,
 ) -> FuelCallResponse<()> {

--- a/multisig-wallet/project/contracts/multisig-contract/tests/utils/interface/info.rs
+++ b/multisig-wallet/project/contracts/multisig-contract/tests/utils/interface/info.rs
@@ -44,7 +44,7 @@ pub async fn transaction_hash(
 
 pub async fn threshold_hash(
     contract: &MultiSig,
-    data: Option<Bits256>,
+    data: Bits256,
     nonce: u64,
     threshold: u64,
 ) -> FuelCallResponse<Bits256> {
@@ -58,7 +58,7 @@ pub async fn threshold_hash(
 
 pub async fn weight_hash(
     contract: &MultiSig,
-    data: Option<Bits256>,
+    data: Bits256,
     nonce: u64,
     user: User,
 ) -> FuelCallResponse<Bits256> {


### PR DESCRIPTION
## Type of change

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Changed `set_threshold` and `set_weight` to require data instead of being optional
- Adjusted tests

## Notes

- It was either this or make everything optional to be consistent. I think it makes more sense to require data even if it's garbage although that may not be the best.

## Related Issues

Closes #590 
