### PR TITLE
Change the type of price in storage

### DIFF
--- a/oracle/project/Forc.lock
+++ b/oracle/project/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = 'core'
-source = 'path+from-root-B0D5F718107CCC86'
+source = 'path+from-root-894BF76E6DA2FFD3'
 
 [[package]]
 name = 'oracle-contract'
@@ -9,5 +9,5 @@ dependencies = ['std']
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.35.2#f05ecaf2de1ebe3b3da80ecd8eb6053a84145cf4'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.35.3#5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff'
 dependencies = ['core']

--- a/oracle/project/contracts/oracle-contract/src/interface.sw
+++ b/oracle/project/contracts/oracle-contract/src/interface.sw
@@ -8,7 +8,7 @@ abi Oracle {
 
     /// Return price of asset
     #[storage(read)]
-    fn price() -> u64;
+    fn price() -> Option<u64>;
 
     /// Changes the price in storage to the value of `price`
     ///

--- a/oracle/project/contracts/oracle-contract/src/main.sw
+++ b/oracle/project/contracts/oracle-contract/src/main.sw
@@ -14,8 +14,7 @@ use interface::Oracle;
 
 storage {
     // Current price of tracked asset
-    // TODO use option when https://github.com/FuelLabs/fuels-rs/issues/415 is fixed
-    price: u64 = 0,
+    price: Option<u64> = Option::None,
 }
 
 // TODO treat owner as an identity once https://github.com/FuelLabs/sway/issues/2647 is fixed
@@ -25,7 +24,7 @@ impl Oracle for Contract {
     }
 
     #[storage(read)]
-    fn price() -> u64 {
+    fn price() -> Option<u64> {
         storage.price
     }
 
@@ -33,7 +32,7 @@ impl Oracle for Contract {
     fn set_price(price: u64) {
         require(msg_sender().unwrap() == Identity::Address(Address::from(OWNER)), AccessError::NotOwner);
 
-        storage.price = price;
+        storage.price = Option::Some(price);
 
         log(PriceUpdateEvent { price });
     }

--- a/oracle/project/contracts/oracle-contract/tests/functions/price.rs
+++ b/oracle/project/contracts/oracle-contract/tests/functions/price.rs
@@ -12,13 +12,13 @@ mod success {
         let set_price_amount: u64 = 1000;
         set_price(&user.oracle, set_price_amount).await;
         let price = price(&user.oracle).await;
-        assert_eq!(price, set_price_amount);
+        assert_eq!(price, Option::Some(set_price_amount));
     }
 
     #[tokio::test]
     async fn can_get_price_when_not_initialized() {
         let (user, _) = setup().await;
         let price = price(&user.oracle).await;
-        assert_eq!(price, 0);
+        assert_eq!(price, Option::None);
     }
 }

--- a/oracle/project/contracts/oracle-contract/tests/functions/set_price.rs
+++ b/oracle/project/contracts/oracle-contract/tests/functions/set_price.rs
@@ -24,7 +24,7 @@ mod success {
                 price: set_price_amount
             }
         );
-        assert_eq!(price, set_price_amount);
+        assert_eq!(price, Option::Some(set_price_amount));
     }
 }
 

--- a/oracle/project/utils/src/lib.rs
+++ b/oracle/project/utils/src/lib.rs
@@ -24,7 +24,7 @@ pub mod abi_calls {
         contract.methods().owner().call().await.unwrap().value
     }
 
-    pub async fn price(contract: &Oracle) -> u64 {
+    pub async fn price(contract: &Oracle) -> Option<u64> {
         contract.methods().price().call().await.unwrap().value
     }
 


### PR DESCRIPTION
## Type of change

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Change the type of `price` in `storage` to `Option<u64>`
- Update tests

## Notes

- I tried to follow the readme at https://github.com/FuelLabs/sway-applications/blob/master/oracle/README.mdbut could not spin up the the node:
```
$ fuel-core run --chain project/oracle-node/.chainConfig.json
Error: an error occurred while loading the chain config file project/oracle-node/.chainConfig.json

Caused by:
    missing field `consensus` at line 35 column 1
$ fuel-core --version                                        
fuel-core 0.17.3
```
Happy to create an issue and work on a fix if needed.

## Related Issues

Closes #448
