### PR TITLE
Include block manipulation in commented escrow tests

### DIFF
--- a/escrow/project/contracts/escrow-contract/tests/functions/core/withdraw_collateral.rs
+++ b/escrow/project/contracts/escrow-contract/tests/functions/core/withdraw_collateral.rs
@@ -116,9 +116,92 @@ mod success {
     }
 
     #[tokio::test]
-    #[ignore]
     async fn withdraws_collateral_in_two_escrows() {
-        // TODO: skipping similar to withdraws_collateral
+        let (arbiter, buyer, seller, defaults) = setup().await;
+        let arbiter_obj = create_arbiter(&arbiter, defaults.asset_id, defaults.asset_amount).await;
+        let asset = create_asset(defaults.asset_amount, defaults.asset_id).await;
+
+        mint(&seller, 2 * defaults.asset_amount, &defaults.asset).await;
+
+        let provider = buyer.wallet.get_provider().unwrap();
+        let origin_block = provider.latest_block_height().await.unwrap();
+
+        create_escrow(
+            defaults.asset_amount,
+            &arbiter_obj,
+            &defaults.asset_id,
+            vec![asset.clone(), asset.clone()],
+            &buyer,
+            &seller,
+            defaults.deadline,
+        )
+        .await;
+        let escrow_id_0 = 0;
+        assert!(matches!(
+            escrows(&seller, escrow_id_0).await.unwrap().state,
+            State::Pending
+        ));
+
+        create_escrow(
+            defaults.asset_amount,
+            &arbiter_obj,
+            &defaults.asset_id,
+            vec![asset.clone(), asset.clone()],
+            &buyer,
+            &seller,
+            defaults.deadline,
+        )
+        .await;
+        let escrow_id_1 = 1;
+        assert!(matches!(
+            escrows(&seller, escrow_id_1).await.unwrap().state,
+            State::Pending
+        ));
+
+        assert_eq!(0, asset_amount(&defaults.asset_id, &seller).await);
+
+        provider
+            .produce_blocks(origin_block + defaults.deadline, None)
+            .await
+            .unwrap();
+
+        let response0 = withdraw_collateral(&seller, escrow_id_0).await;
+        let response1 = withdraw_collateral(&seller, escrow_id_1).await;
+
+        assert_eq!(
+            2 * defaults.asset_amount,
+            asset_amount(&defaults.asset_id, &seller).await
+        );
+        assert!(matches!(
+            escrows(&seller, escrow_id_0).await.unwrap().state,
+            State::Completed
+        ));
+        assert!(matches!(
+            escrows(&seller, escrow_id_1).await.unwrap().state,
+            State::Completed
+        ));
+
+        let log0 = response0
+            .get_logs_with_type::<WithdrawnCollateralEvent>()
+            .unwrap();
+        let event0 = log0.get(0).unwrap();
+        assert_eq!(
+            *event0,
+            WithdrawnCollateralEvent {
+                identifier: escrow_id_0
+            }
+        );
+
+        let log1 = response1
+            .get_logs_with_type::<WithdrawnCollateralEvent>()
+            .unwrap();
+        let event1 = log1.get(0).unwrap();
+        assert_eq!(
+            *event1,
+            WithdrawnCollateralEvent {
+                identifier: escrow_id_1
+            }
+        );
     }
 }
 

--- a/escrow/project/contracts/escrow-contract/tests/harness.rs
+++ b/escrow/project/contracts/escrow-contract/tests/harness.rs
@@ -1,6 +1,5 @@
 // TODO:
 //      when getters are added check values have changed
-//      SDK block manipulation
 //      SDK vec support -> change contract from array to vec
 
 mod functions;

--- a/escrow/project/contracts/escrow-contract/tests/utils/setup.rs
+++ b/escrow/project/contracts/escrow-contract/tests/utils/setup.rs
@@ -1,7 +1,8 @@
 use fuels::{
     prelude::{
-        abigen, launch_custom_provider_and_get_wallets, Address, AssetId, Configurables, Contract,
-        ContractId, Salt, StorageConfiguration, TxParameters, WalletUnlocked, WalletsConfig,
+        abigen, launch_custom_provider_and_get_wallets, Address, AssetId, Config, Configurables,
+        Contract, ContractId, Salt, StorageConfiguration, TxParameters, WalletUnlocked,
+        WalletsConfig,
     },
     types::Identity,
 };
@@ -121,13 +122,18 @@ pub(crate) async fn setup() -> (User, User, User, Defaults) {
     let coins_per_wallet = 1;
     let amount_per_coin = 1_000_000;
 
-    let config = WalletsConfig::new(
+    let wallet_config = WalletsConfig::new(
         Some(number_of_wallets),
         Some(coins_per_wallet),
         Some(amount_per_coin),
     );
+    let provider_config = Config {
+        manual_blocks_enabled: true,
+        ..Config::local_node()
+    };
 
-    let mut wallets = launch_custom_provider_and_get_wallets(config, None, None).await;
+    let mut wallets =
+        launch_custom_provider_and_get_wallets(wallet_config, Some(provider_config), None).await;
 
     let deployer_wallet = wallets.pop().unwrap();
     let arbiter_wallet = wallets.pop().unwrap();


### PR DESCRIPTION
## Type of change

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The wallets provider config is modified to set `manual_blocks_enabled` to true, then all the implemented tests that were ignored because of lack of block manipulation are un-ignored and modified to pass.

## Notes

There are still some tests ignored but unimplemented, let me know if they should be implemented as part of this PR.

## Related Issues

Closes #220
