### PR TITLE
AMM: replaced `SCRIPT_GAS_LIMIT` in favour of `.estimate_transaction_cost()`

### DIFF
--- a/AMM/project/scripts/atomic-add-liquidity/tests/cases/revert.rs
+++ b/AMM/project/scripts/atomic-add-liquidity/tests/cases/revert.rs
@@ -42,7 +42,7 @@ async fn when_desired_liquidity_too_high() {
 
     let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
 
-    script_instance
+    let script_instance_call = script_instance
         .main(
             exchange.id,
             LiquidityParameters {

--- a/AMM/project/scripts/atomic-add-liquidity/tests/cases/success.rs
+++ b/AMM/project/scripts/atomic-add-liquidity/tests/cases/success.rs
@@ -17,7 +17,7 @@ async fn adds_liquidity_with_equal_deposit_amounts() {
     let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
 
     // add initial liquidity with amounts 1000:1000
-    let script_instance_call = script_instance
+    let mut script_call_handler = script_instance
         .main(
             exchange.id,
             LiquidityParameters {
@@ -37,13 +37,14 @@ async fn adds_liquidity_with_equal_deposit_amounts() {
         )
         .set_contracts(&[&exchange.instance])
         .with_inputs(transaction_parameters.inputs)
-        .with_outputs(transaction_parameters.outputs)
-        .tx_params(TxParameters::new(0, SCRIPT_GAS_LIMIT, 0));
+        .with_outputs(transaction_parameters.outputs);
+        // .tx_params(TxParameters::new(0, SCRIPT_GAS_LIMIT, 0));
 
-        let gas_used = script_instance_call
-        .provider
-        .estimate_transaction_cost(&script_instance_call, Some(0.0))
-        .await;
+        let estimated_gas = script_call_handler
+            .estimate_transaction_cost(Some(0.0))
+            .await
+            .unwrap()
+            .gas_used;
 
         // .call()
         // .await

--- a/AMM/project/scripts/atomic-add-liquidity/tests/cases/success.rs
+++ b/AMM/project/scripts/atomic-add-liquidity/tests/cases/success.rs
@@ -17,7 +17,7 @@ async fn adds_liquidity_with_equal_deposit_amounts() {
     let expected_liquidity = expected_liquidity(&exchange, &liquidity_parameters, false).await;
 
     // add initial liquidity with amounts 1000:1000
-    let liquidity = script_instance
+    let script_instance_call = script_instance
         .main(
             exchange.id,
             LiquidityParameters {
@@ -38,11 +38,23 @@ async fn adds_liquidity_with_equal_deposit_amounts() {
         .set_contracts(&[&exchange.instance])
         .with_inputs(transaction_parameters.inputs)
         .with_outputs(transaction_parameters.outputs)
-        .tx_params(TxParameters::new(0, SCRIPT_GAS_LIMIT, 0))
-        .call()
-        .await
-        .unwrap()
-        .value;
+        .tx_params(TxParameters::new(0, SCRIPT_GAS_LIMIT, 0));
+
+        let gas_used = script_instance_call
+        .provider
+        .estimate_transaction_cost(&script_instance_call, Some(0.0))
+        .await;
+
+        // .call()
+        // .await
+        // .unwrap()
+        // .value;
+
+    // let contract_instance_call = &exchange
+    //     .methods()
+    //     .estimate_transaction_cost(None)
+    //     .await
+    //     .gas_used;
 
     assert_eq!(expected_liquidity, liquidity);
 }


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix
- New feature
- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)
- Documentation
- Other (describe below)

## Changes

The following changes have been made:

- Change 1
- Change 2

## Notes

- Note 1

## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #\<issue number\>
