### PR TITLE
Remove typo in English-auction's Forc.toml

### DIFF
--- a/auctions/english-auction/project/Forc.toml
+++ b/auctions/english-auction/project/Forc.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["./contracts/auction-contract", "./contracts/test-artifacts//NFT"]
+members = ["./contracts/auction-contract", "./contracts/test-artifacts/NFT"]


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Removed typo 



## Related Issues

<!--Delete everything after the "#" symbol and replace it with a number. No spaces between hash and number-->

Closes #709 
