### PR TITLE
Update links for multi-token standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ sway-applications/
 - [Escrow](./escrow) is a third party that keeps an asset on behalf of multiple parties.
 
 > **Warning**
-> The `Fractional-NFT` has been archived until the release of the [Sway multi-token standard](https://github.com/FuelLabs/rfcs/pull/17).
+> The `Fractional-NFT` has been archived until the release of the [Sway multi-token standard](https://github.com/FuelLabs/sway-standards/issues/1).
 
 - [Fractional-NFT](./archive/fractional-NFT/) allows multiple parties to claim ownership of an NFT directly proportional to the number of tokens they hold.
 
 > **Warning**
-> The `Non-Fungible Token (NFT)` has been archived until the release of the [Sway multi-token standard](https://github.com/FuelLabs/rfcs/pull/17).
+> The `Non-Fungible Token (NFT)` has been archived until the release of the [Sway multi-token standard](https://github.com/FuelLabs/sway-standards/issues/1).
 
 - [Non-Fungible Token (NFT)](./archive/NFT) is a token contract which provides unique collectibles, identified and differentiated by token IDs, where tokens contain metadata giving them distinctive characteristics.
 - [Timelock](./timelock) is a contract which restricts the execution of a transaction to a specified time range.

--- a/archive/NFT/README.md
+++ b/archive/NFT/README.md
@@ -18,7 +18,7 @@
 </p>
 
 > **Warning**
-> This application have been temporarily archived until the release of the [Sway multi-token standard](https://github.com/FuelLabs/rfcs/pull/17). In its current form, it does not comply with the standard and as such should be considered outdated.
+> This application have been temporarily archived until the release of the [Sway multi-token standard](https://github.com/FuelLabs/sway-standards/issues/1). In its current form, it does not comply with the standard and as such should be considered outdated.
 > It is inadvisable to use this application for production purposes.
 
 ## Overview

--- a/archive/README.md
+++ b/archive/README.md
@@ -1,6 +1,6 @@
 ## Archived Apps
 
-The following applications have been temporarily archived as they are awaiting the release of the [Sway multi-token standard](https://github.com/FuelLabs/rfcs/pull/17) before being updated. In their current form, they do not comply with this standard and as such should be considered outdated.
+The following applications have been temporarily archived as they are awaiting the release of the [Sway multi-token standard](https://github.com/FuelLabs/sway-standards/issues/1) before being updated. In their current form, they do not comply with this standard and as such should be considered outdated.
 
 > **Warning**
 > It is inadvisable to use them for production purposes.

--- a/archive/fractional-NFT/README.md
+++ b/archive/fractional-NFT/README.md
@@ -18,7 +18,7 @@
 </p>
 
 > **Warning**
-> This application have been temporarily archived until the release of the [Sway multi-token standard](https://github.com/FuelLabs/rfcs/pull/17). In its current form, it does not comply with this standard and as such should be considered outdated.
+> This application have been temporarily archived until the release of the [Sway multi-token standard](https://github.com/FuelLabs/sway-standards/issues/1). In its current form, it does not comply with this standard and as such should be considered outdated.
 > It is inadvisable to use this application for production purposes.
 
 ## Overview


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Documentation

## Changes

The following changes have been made:

- Updated links to point to sway multi token standard in the RFCS repo. This should instead point to either the [fuel spec changes](https://github.com/FuelLabs/fuel-specs/pull/491) or the [SRC-20 standard](https://github.com/FuelLabs/sway-standards/issues/1). I have opted for the SRC-20 standard as it is more user facing.

## Notes

- The previous links pointed to an RFC
