### PR TITLE
Bump staging to forc v0.48.1

### DIFF
--- a/DAO/project/Forc.lock
+++ b/DAO/project/Forc.lock
@@ -5,9 +5,9 @@ dependencies = ["std"]
 
 [[package]]
 name = "core"
-source = "path+from-root-AC247AEA3D39B916"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.47.0#34265301c6037d51444899a99df1cfc563df6016"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]

--- a/DAO/project/fuel-toolchain.toml
+++ b/DAO/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-11-20"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.47.0"
-fuel-core = "0.20.8"
+forc = "0.48.1"
+fuel-core = "0.21.0"

--- a/airdrop/project/Forc.lock
+++ b/airdrop/project/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "core"
-source = "path+from-root-C8151CEA96BFFBEE"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "distributor-contract"
@@ -12,10 +12,10 @@ dependencies = [
 
 [[package]]
 name = "merkle_proof"
-source = "git+https://github.com/FuelLabs/sway-libs?branch=ls/feat/std-policies-branch#2cb5cc2ccb1e26d99568530e84e42ffcc0e6f338"
+source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.17.2#5d69f665207158517eba14c35c7d28cb1cb93aa9"
 dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?branch=feat/transaction-policies#ab408484d14dc368ba6ed77d8e069cce0eb47fe4"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]

--- a/airdrop/project/Forc.toml
+++ b/airdrop/project/Forc.toml
@@ -1,5 +1,2 @@
 [workspace]
 members = ["./contracts/distributor-contract"]
-
-[patch.'https://github.com/fuellabs/sway']
-std = { git = "https://github.com/fuellabs/sway", branch = "feat/transaction-policies" }

--- a/airdrop/project/contracts/distributor-contract/Forc.toml
+++ b/airdrop/project/contracts/distributor-contract/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "distributor-contract"
 
 [dependencies]
-merkle_proof = { git = "https://github.com/FuelLabs/sway-libs", branch = "ls/feat/std-policies-branch" }
+merkle_proof = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.17.2" }

--- a/airdrop/project/fuel-toolchain.toml
+++ b/airdrop/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-11-20"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.47.0"
-fuel-core = "0.20.8"
+forc = "0.48.1"
+fuel-core = "0.21.0"

--- a/auctions/english-auction/project/Forc.lock
+++ b/auctions/english-auction/project/Forc.lock
@@ -5,9 +5,9 @@ dependencies = ["std"]
 
 [[package]]
 name = "core"
-source = "path+from-root-C8151CEA96BFFBEE"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?branch=feat/transaction-policies#ab408484d14dc368ba6ed77d8e069cce0eb47fe4"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]

--- a/auctions/english-auction/project/Forc.toml
+++ b/auctions/english-auction/project/Forc.toml
@@ -1,5 +1,2 @@
 [workspace]
 members = ["./contracts/auction-contract"]
-
-[patch.'https://github.com/fuellabs/sway']
-std = { git = "https://github.com/fuellabs/sway", branch = "feat/transaction-policies" }

--- a/auctions/english-auction/project/fuel-toolchain.toml
+++ b/auctions/english-auction/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-11-20"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.47.0"
-fuel-core = "0.20.8"
+forc = "0.48.1"
+fuel-core = "0.21.0"

--- a/counter-script/project/Forc.lock
+++ b/counter-script/project/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "core"
-source = "path+from-root-AC247AEA3D39B916"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "counter_contract"
@@ -25,5 +25,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.47.0#34265301c6037d51444899a99df1cfc563df6016"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]

--- a/counter-script/project/fuel-toolchain.toml
+++ b/counter-script/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-11-20"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.47.0"
-fuel-core = "0.20.8"
+forc = "0.48.1"
+fuel-core = "0.21.0"

--- a/games/TicTacToe/project/Forc.lock
+++ b/games/TicTacToe/project/Forc.lock
@@ -1,10 +1,10 @@
 [[package]]
 name = "core"
-source = "path+from-root-AC247AEA3D39B916"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.47.0#34265301c6037d51444899a99df1cfc563df6016"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]
 
 [[package]]

--- a/games/TicTacToe/project/contracts/tictactoe-contract/src/main.sw
+++ b/games/TicTacToe/project/contracts/tictactoe-contract/src/main.sw
@@ -14,18 +14,6 @@ use ::interface::Game;
 use std::{auth::msg_sender, hash::Hash};
 use ::utils::{draw, win_check};
 
-// This is needed for comparing the position when the cell is not empty.
-// We only need to check if there is an Identity in the cell but we don't care about its value.
-impl<T> Eq for Option<T> {
-    fn eq(self, other: Self) -> bool {
-        match (self, other) {
-            (Option::None, Option::None) => true,
-            (Option::Some(_), Option::Some(_)) => true,
-            _ => false,
-        }
-    }
-}
-
 storage {
     /// Keeps track of each player move.
     board: StorageMap<u64, Identity> = StorageMap {},

--- a/games/TicTacToe/project/fuel-toolchain.toml
+++ b/games/TicTacToe/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-11-20"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.47.0"
-fuel-core = "0.20.8"
+forc = "0.48.1"
+fuel-core = "0.21.0"

--- a/multisig-wallet/project/Forc.lock
+++ b/multisig-wallet/project/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "core"
-source = "path+from-root-AC247AEA3D39B916"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "multisig-contract"
@@ -9,7 +9,7 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.47.0#34265301c6037d51444899a99df1cfc563df6016"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]
 
 [[package]]

--- a/multisig-wallet/project/fuel-toolchain.toml
+++ b/multisig-wallet/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-11-20"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.47.0"
-fuel-core = "0.20.8"
+forc = "0.48.1"
+fuel-core = "0.21.0"

--- a/oracle/project/Forc.lock
+++ b/oracle/project/Forc.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "core"
-source = "path+from-root-AC247AEA3D39B916"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "oracle-contract"
@@ -9,5 +9,5 @@ dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.47.0#34265301c6037d51444899a99df1cfc563df6016"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]

--- a/oracle/project/fuel-toolchain.toml
+++ b/oracle/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-11-20"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.47.0"
-fuel-core = "0.20.8"
+forc = "0.48.1"
+fuel-core = "0.21.0"

--- a/timelock/project/Forc.lock
+++ b/timelock/project/Forc.lock
@@ -1,10 +1,10 @@
 [[package]]
 name = "core"
-source = "path+from-root-AC247AEA3D39B916"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.47.0#34265301c6037d51444899a99df1cfc563df6016"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]
 
 [[package]]

--- a/timelock/project/fuel-toolchain.toml
+++ b/timelock/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-11-20"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.47.0"
-fuel-core = "0.20.8"
+forc = "0.48.1"
+fuel-core = "0.21.0"


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates the staging branch to forc v0.48.1
- Updates sway-libs to v0.17.2 
- Updates sway-standards to v0.2.2

## Notes

- This is required for https://github.com/FuelLabs/sway-applications/pull/761
