### PR TITLE
Bump Native Assets Applications to forc v0.48.1

### DIFF
--- a/native-assets/NFT/README.md
+++ b/native-assets/NFT/README.md
@@ -6,11 +6,11 @@
 </p>
 
 <p align="center">
-    <a href="https://crates.io/crates/forc/0.46.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.46.1-orange" />
+    <a href="https://crates.io/crates/forc/0.48.1" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.48.1-orange" />
     </a>
-    <a href="https://crates.io/crates/fuel-core/0.20.4" alt="fuel-core">
-        <img src="https://img.shields.io/badge/fuel--core-v0.20.4-yellow" />
+    <a href="https://crates.io/crates/fuel-core/0.21.0" alt="fuel-core">
+        <img src="https://img.shields.io/badge/fuel--core-v0.21.0-yellow" />
     </a>
 </p>
 

--- a/native-assets/NFT/project/Forc.lock
+++ b/native-assets/NFT/project/Forc.lock
@@ -11,31 +11,31 @@ dependencies = [
 
 [[package]]
 name = "core"
-source = "path+from-root-AD80769CAE44474A"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "src_20"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.1.2#a3744aa3dcb8c950a433d1fc16645ef9a83dc583"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.2.2#6989cf8224b0d8aabea62f3d3c648fc754948705"
 dependencies = ["std"]
 
 [[package]]
 name = "src_3"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.1.2#a3744aa3dcb8c950a433d1fc16645ef9a83dc583"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.2.2#6989cf8224b0d8aabea62f3d3c648fc754948705"
 dependencies = ["std"]
 
 [[package]]
 name = "src_7"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.1.2#a3744aa3dcb8c950a433d1fc16645ef9a83dc583"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.2.2#6989cf8224b0d8aabea62f3d3c648fc754948705"
 dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.46.0#e75f14b03636bc96751a6760304a1a6d3eb5937d"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]
 
 [[package]]
 name = "token"
-source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.15.0#5257dc7f19d1893df749cd84240fee4158a12481"
+source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.17.2#5d69f665207158517eba14c35c7d28cb1cb93aa9"
 dependencies = [
     "src_7",
     "std",

--- a/native-assets/NFT/project/contracts/NFT-contract/Forc.toml
+++ b/native-assets/NFT/project/contracts/NFT-contract/Forc.toml
@@ -5,7 +5,7 @@ license = "Apache-2.0"
 name = "NFT-contract"
 
 [dependencies]
-src_20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.2" }
-src_3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.2" }
-src_7 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.2" }
-token = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.15.0" }
+src_20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }
+src_3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }
+src_7 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }
+token = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.17.2" }

--- a/native-assets/NFT/project/contracts/NFT-contract/src/main.sw
+++ b/native-assets/NFT/project/contracts/NFT-contract/src/main.sw
@@ -241,9 +241,30 @@ impl SRC3 for Contract {
     fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
         let asset = AssetId::new(contract_id(), sub_id);
         require(amount == 1, MintError::CannotMintMoreThanOneNFTWithSubId);
-        require(storage.total_supply.get(asset).try_read().is_none(), MintError::NFTAlreadyMinted);
-        require(storage.total_assets.try_read().unwrap_or(0) + amount <= 100_000, MintError::MaxNFTsMinted);
-        let _ = _mint(storage.total_assets, storage.total_supply, recipient, sub_id, amount);
+        require(
+            storage
+                .total_supply
+                .get(asset)
+                .try_read()
+                .is_none(),
+            MintError::NFTAlreadyMinted,
+        );
+        require(
+            storage
+                .total_assets
+                .try_read()
+                .unwrap_or(0) + amount <= 100_000,
+            MintError::MaxNFTsMinted,
+        );
+        let _ = _mint(
+            storage
+                .total_assets,
+            storage
+                .total_supply,
+            recipient,
+            sub_id,
+            amount,
+        );
     }
     /// Burns tokens sent with the given `sub_id`.
     ///
@@ -351,7 +372,14 @@ impl SetTokenAttributes for Contract {
     /// ```
     #[storage(write)]
     fn set_name(asset: AssetId, name: String) {
-        require(storage.name.get(asset).read_slice().is_none(), SetError::ValueAlreadySet);
+        require(
+            storage
+                .name
+                .get(asset)
+                .read_slice()
+                .is_none(),
+            SetError::ValueAlreadySet,
+        );
         _set_name(storage.name, asset, name);
     }
     /// Sets the symbol of an asset.
@@ -387,7 +415,14 @@ impl SetTokenAttributes for Contract {
     /// ```
     #[storage(write)]
     fn set_symbol(asset: AssetId, symbol: String) {
-        require(storage.symbol.get(asset).read_slice().is_none(), SetError::ValueAlreadySet);
+        require(
+            storage
+                .symbol
+                .get(asset)
+                .read_slice()
+                .is_none(),
+            SetError::ValueAlreadySet,
+        );
         _set_symbol(storage.symbol, asset, symbol);
     }
     /// This function should never be called.
@@ -440,7 +475,13 @@ impl SetTokenMetadata for Contract {
     /// ```
     #[storage(read, write)]
     fn set_metadata(asset: AssetId, key: String, metadata: Metadata) {
-        require(storage.metadata.get(asset, key).is_none(), SetError::ValueAlreadySet);
+        require(
+            storage
+                .metadata
+                .get(asset, key)
+                .is_none(),
+            SetError::ValueAlreadySet,
+        );
         _set_metadata(storage.metadata, asset, key, metadata);
     }
 }
@@ -526,7 +567,13 @@ fn test_name() {
     let name = String::from_ascii_str("Fuel Token");
     assert(src20_abi.name(asset_id).is_none());
     attributes_abi.set_name(asset_id, name);
-    assert(src20_abi.name(asset_id).unwrap().as_bytes() == name.as_bytes());
+    assert(
+        src20_abi
+            .name(asset_id)
+            .unwrap()
+            .as_bytes() == name
+            .as_bytes(),
+    );
 }
 #[test(should_revert)]
 fn test_revert_set_name_twice() {
@@ -548,7 +595,13 @@ fn test_symbol() {
     let symbol = String::from_ascii_str("FUEL");
     assert(src20_abi.symbol(asset_id).is_none());
     attributes_abi.set_symbol(asset_id, symbol);
-    assert(src20_abi.symbol(asset_id).unwrap().as_bytes() == symbol.as_bytes());
+    assert(
+        src20_abi
+            .symbol(asset_id)
+            .unwrap()
+            .as_bytes() == symbol
+            .as_bytes(),
+    );
 }
 #[test(should_revert)]
 fn test_revert_set_symbol_twice() {

--- a/native-assets/NFT/project/fuel-toolchain.toml
+++ b/native-assets/NFT/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-09-29"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.46.0"
-fuel-core = "0.20.5"
+forc = "0.48.1"
+fuel-core = "0.21.0"

--- a/native-assets/token/README.md
+++ b/native-assets/token/README.md
@@ -6,11 +6,11 @@
 </p>
 
 <p align="center">
-    <a href="https://crates.io/crates/forc/0.46.1" alt="forc">
-        <img src="https://img.shields.io/badge/forc-v0.46.1-orange" />
+    <a href="https://crates.io/crates/forc/0.48.1" alt="forc">
+        <img src="https://img.shields.io/badge/forc-v0.48.1-orange" />
     </a>
-    <a href="https://crates.io/crates/fuel-core/0.20.4" alt="fuel-core">
-        <img src="https://img.shields.io/badge/fuel--core-v0.20.4-yellow" />
+    <a href="https://crates.io/crates/fuel-core/0.21.0" alt="fuel-core">
+        <img src="https://img.shields.io/badge/fuel--core-v0.21.0-yellow" />
     </a>
 </p>
 

--- a/native-assets/token/project/Forc.lock
+++ b/native-assets/token/project/Forc.lock
@@ -1,30 +1,30 @@
 [[package]]
 name = "core"
-source = "path+from-root-AD80769CAE44474A"
+source = "path+from-root-B77DA2F383183718"
 
 [[package]]
 name = "src_20"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.1.2#a3744aa3dcb8c950a433d1fc16645ef9a83dc583"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.2.2#6989cf8224b0d8aabea62f3d3c648fc754948705"
 dependencies = ["std"]
 
 [[package]]
 name = "src_3"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.1.2#a3744aa3dcb8c950a433d1fc16645ef9a83dc583"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.2.2#6989cf8224b0d8aabea62f3d3c648fc754948705"
 dependencies = ["std"]
 
 [[package]]
 name = "src_7"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.1.2#a3744aa3dcb8c950a433d1fc16645ef9a83dc583"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.2.2#6989cf8224b0d8aabea62f3d3c648fc754948705"
 dependencies = ["std"]
 
 [[package]]
 name = "std"
-source = "git+https://github.com/fuellabs/sway?tag=v0.46.0#e75f14b03636bc96751a6760304a1a6d3eb5937d"
+source = "git+https://github.com/fuellabs/sway?tag=v0.48.1#6886ef050ce62afd3fe3186ed562fd33bd76bffa"
 dependencies = ["core"]
 
 [[package]]
 name = "token"
-source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.15.0#5257dc7f19d1893df749cd84240fee4158a12481"
+source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.17.2#5d69f665207158517eba14c35c7d28cb1cb93aa9"
 dependencies = [
     "src_7",
     "std",

--- a/native-assets/token/project/contracts/token-contract/Forc.toml
+++ b/native-assets/token/project/contracts/token-contract/Forc.toml
@@ -5,6 +5,6 @@ license = "Apache-2.0"
 name = "token-contract"
 
 [dependencies]
-src_20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.2" }
-src_3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.1.2" }
-token = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.15.0" }
+src_20 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }
+src_3 = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.2.2" }
+token = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.17.2" }

--- a/native-assets/token/project/contracts/token-contract/src/main.sw
+++ b/native-assets/token/project/contracts/token-contract/src/main.sw
@@ -25,10 +25,15 @@ use token::{
 use std::{call_frames::contract_id, hash::Hash, storage::storage_string::*, string::String};
 
 storage {
+    /// The total number of unique assets minted by this contract.
     total_assets: u64 = 0,
+    /// The total number of tokens minted for a particular asset.
     total_supply: StorageMap<AssetId, u64> = StorageMap {},
+    /// The name associated with a particular asset.
     name: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// The symbol associated with a particular asset.
     symbol: StorageMap<AssetId, StorageString> = StorageMap {},
+    /// The decimals associated with a particular asset.
     decimals: StorageMap<AssetId, u8> = StorageMap {},
 }
 
@@ -215,8 +220,23 @@ impl SRC3 for Contract {
     #[storage(read, write)]
     fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
         let asset = AssetId::new(contract_id(), sub_id);
-        require(storage.total_supply.get(asset).try_read().unwrap_or(0) + amount < 100_000_000, MintError::MaxMinted);
-        let _ = _mint(storage.total_assets, storage.total_supply, recipient, sub_id, amount);
+        require(
+            storage
+                .total_supply
+                .get(asset)
+                .try_read()
+                .unwrap_or(0) + amount < 100_000_000,
+            MintError::MaxMinted,
+        );
+        let _ = _mint(
+            storage
+                .total_assets,
+            storage
+                .total_supply,
+            recipient,
+            sub_id,
+            amount,
+        );
     }
     /// Burns tokens sent with the given `sub_id`.
     ///
@@ -289,7 +309,14 @@ impl SetTokenAttributes for Contract {
     /// ```
     #[storage(write)]
     fn set_name(asset: AssetId, name: String) {
-        require(storage.name.get(asset).read_slice().is_none(), SetError::ValueAlreadySet);
+        require(
+            storage
+                .name
+                .get(asset)
+                .read_slice()
+                .is_none(),
+            SetError::ValueAlreadySet,
+        );
         _set_name(storage.name, asset, name);
     }
     /// Sets the symbol of an asset.
@@ -325,7 +352,14 @@ impl SetTokenAttributes for Contract {
     /// ```
     #[storage(write)]
     fn set_symbol(asset: AssetId, symbol: String) {
-        require(storage.symbol.get(asset).read_slice().is_none(), SetError::ValueAlreadySet);
+        require(
+            storage
+                .symbol
+                .get(asset)
+                .read_slice()
+                .is_none(),
+            SetError::ValueAlreadySet,
+        );
         _set_symbol(storage.symbol, asset, symbol);
     }
     /// Sets the decimals of an asset.
@@ -360,7 +394,14 @@ impl SetTokenAttributes for Contract {
     /// ```
     #[storage(write)]
     fn set_decimals(asset: AssetId, decimals: u8) {
-        require(storage.decimals.get(asset).try_read().is_none(), SetError::ValueAlreadySet);
+        require(
+            storage
+                .decimals
+                .get(asset)
+                .try_read()
+                .is_none(),
+            SetError::ValueAlreadySet,
+        );
         _set_decimals(storage.decimals, asset, decimals);
     }
 }
@@ -436,7 +477,13 @@ fn test_name() {
     let name = String::from_ascii_str("Fuel Token");
     assert(src20_abi.name(asset_id).is_none());
     attributes_abi.set_name(asset_id, name);
-    assert(src20_abi.name(asset_id).unwrap().as_bytes() == name.as_bytes());
+    assert(
+        src20_abi
+            .name(asset_id)
+            .unwrap()
+            .as_bytes() == name
+            .as_bytes(),
+    );
 }
 #[test(should_revert)]
 fn test_revert_set_name_twice() {
@@ -458,7 +505,13 @@ fn test_symbol() {
     let symbol = String::from_ascii_str("FUEL");
     assert(src20_abi.symbol(asset_id).is_none());
     attributes_abi.set_symbol(asset_id, symbol);
-    assert(src20_abi.symbol(asset_id).unwrap().as_bytes() == symbol.as_bytes());
+    assert(
+        src20_abi
+            .symbol(asset_id)
+            .unwrap()
+            .as_bytes() == symbol
+            .as_bytes(),
+    );
 }
 #[test(should_revert)]
 fn test_revert_set_symbol_twice() {

--- a/native-assets/token/project/fuel-toolchain.toml
+++ b/native-assets/token/project/fuel-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
-channel = "latest-2023-09-29"
+channel = "nightly-2023-12-06"
 
 [components]
-forc = "0.46.0"
-fuel-core = "0.20.4"
+forc = "0.48.1"
+fuel-core = "0.21.0"


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Bumps NFT and Token apps to forc v0.48.1
- Bumps NFT and Token apps to use sway-libs v0.17.2
- Bumps NFT and Token apps to use sway-standard v0.2.2

## Notes

-These are the final applications that need to be bumped for all apps to use forc v0.48.1
