### PR TITLE
Reduce Read/writes and add `get_board()` for TicTacToe

### DIFF
--- a/games/TicTacToe/project/SPECIFICATION.md
+++ b/games/TicTacToe/project/SPECIFICATION.md
@@ -4,6 +4,7 @@ Table of Contents
   - [Core Functionality](#core-functionality)
     - [`new_game()`](#new_game)
     - [`make_move()`](#make_move)
+    - [`get_board()`](#get_board)
   - [Diagrams](#diagrams)
     - [Sequence Diagram](#sequence-diagram)
 
@@ -36,6 +37,10 @@ If you are interested in a functional overview then this is the section for you.
    2. If the incorrect player tries to make a move.
    3. If a player tries to make a move out of bounds.
    4. If a player tries to make a move to an occupied cell.
+
+### `get_board()`
+
+View function to return the player positions in the current game.
 
 ## Diagrams
 

--- a/games/TicTacToe/project/SPECIFICATION.md
+++ b/games/TicTacToe/project/SPECIFICATION.md
@@ -5,6 +5,9 @@ Table of Contents
     - [`new_game()`](#new_game)
     - [`make_move()`](#make_move)
     - [`get_board()`](#get_board)
+    - [`get_game_state()`](#get_game_state)
+    - [`get_current_player()`](#get_current_player)
+    - [`get_players()`](#get_players)
   - [Diagrams](#diagrams)
     - [Sequence Diagram](#sequence-diagram)
 
@@ -41,6 +44,18 @@ If you are interested in a functional overview then this is the section for you.
 ### `get_board()`
 
 View function to return the player positions in the current game.
+
+### `get_game_state()`
+
+View function to return the current state of the game.
+
+### `get_current_player()`
+
+View function to return the player who's turn it is to make a move.
+
+### `get_players()`
+
+View function to return the players of the current game.
 
 ## Diagrams
 

--- a/games/TicTacToe/project/contracts/tictactoe-contract/src/interface.sw
+++ b/games/TicTacToe/project/contracts/tictactoe-contract/src/interface.sw
@@ -11,6 +11,11 @@ abi Game {
     /// # Reverts
     ///
     /// * When there is a game playing.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads - `1`
+    /// * Writes - `14`
     #[storage(read, write)]
     fn new_game(player_one: Identity, player_two: Identity);
 
@@ -30,6 +35,23 @@ abi Game {
     /// * When the wrong player is trying to make a move.
     /// * When a player makes a move out of bounds.
     /// * When a player tries to make a move in an occupied cell.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads - `8`
+    /// * Writes - `3`
     #[storage(read, write)]
     fn make_move(position: u64);
+
+    /// Returns the player positions of the current game as a vector.
+    ///
+    /// # Returns
+    ///
+    /// * [Vec<Option<Identity>>] - The current positions of all players on the board.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads - `1`
+    #[storage(read)]
+    fn get_board() -> Vec<Option<Identity>>;
 }

--- a/games/TicTacToe/project/contracts/tictactoe-contract/src/interface.sw
+++ b/games/TicTacToe/project/contracts/tictactoe-contract/src/interface.sw
@@ -15,7 +15,7 @@ abi Game {
     /// # Number of Storage Accesses
     ///
     /// * Reads - `1`
-    /// * Writes - `14`
+    /// * Writes - `6`
     #[storage(read, write)]
     fn new_game(player_one: Identity, player_two: Identity);
 

--- a/games/TicTacToe/project/contracts/tictactoe-contract/src/interface.sw
+++ b/games/TicTacToe/project/contracts/tictactoe-contract/src/interface.sw
@@ -1,5 +1,7 @@
 library;
 
+use ::data_structures::State;
+
 abi Game {
     /// Starts a new game.
     ///
@@ -54,4 +56,40 @@ abi Game {
     /// * Reads - `1`
     #[storage(read)]
     fn get_board() -> Vec<Option<Identity>>;
+
+    /// Returns the current state of the game.
+    ///
+    /// # Returns
+    ///
+    /// * [State] - The current states of the game.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads - `1`
+    #[storage(read)]
+    fn get_game_state() -> State;
+
+    /// Returns the player who's turn it is to make a move.
+    ///
+    /// # Returns
+    ///
+    /// * [Identity] - The current player.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads - `2`
+    #[storage(read)]
+    fn get_current_player() -> Option<Identity>;
+
+    /// Returns the players of the current game.
+    ///
+    /// # Returns
+    ///
+    /// * [(Identity, Identity)] - A tuple of player 1 and player 2.
+    ///
+    /// # Number of Storage Accesses
+    ///
+    /// * Reads - `3`
+    #[storage(read)]
+    fn get_players() -> Option<(Identity, Identity)>;
 }

--- a/games/TicTacToe/project/contracts/tictactoe-contract/src/main.sw
+++ b/games/TicTacToe/project/contracts/tictactoe-contract/src/main.sw
@@ -11,12 +11,12 @@ use ::data_structures::State;
 use ::errors::{GameStateError, PlayerError, PositionError};
 use ::events::{GameDrawnEvent, GameWonEvent, NewGameEvent};
 use ::interface::Game;
-use std::{auth::msg_sender, hash::Hash};
+use std::{auth::msg_sender, hash::Hash, storage::storage_vec::*};
 use ::utils::{draw, win_check};
 
 storage {
     /// Keeps track of each player move.
-    board: StorageMap<u64, Identity> = StorageMap {},
+    board: StorageVec<Option<Identity>> = StorageVec {},
     /// Keeps track of the move counter for various checks (win, draw, etc.).
     move_counter: u64 = 0,
     /// The first player of the game.
@@ -39,14 +39,14 @@ impl Game for Contract {
             GameStateError::GameHasNotEnded,
         );
 
-        storage.player_one.write(Option::Some(player_one));
-        storage.player_two.write(Option::Some(player_two));
-        storage.player_turn.write(Option::Some(player_one));
+        storage.player_one.write(Some(player_one));
+        storage.player_two.write(Some(player_two));
+        storage.player_turn.write(Some(player_one));
 
         // Once a game has been played we need to reset all values.
         let mut position = 0;
         while position < 9 {
-            let _ = storage.board.remove(position);
+            let _ = storage.board.set(position, None);
             position += 1;
         }
         storage.move_counter.write(0);
@@ -60,78 +60,71 @@ impl Game for Contract {
 
     #[storage(read, write)]
     fn make_move(position: u64) {
+        // Ensure the game is active
         require(
             storage
                 .state
                 .read() == State::Playing,
             GameStateError::GameHasEnded,
         );
+
+        // Only the current player may play
+        let current_player = storage.player_turn.read().unwrap();
         require(
-            storage
-                .player_turn
-                .read()
-                .unwrap() == msg_sender()
+            current_player == msg_sender()
                 .unwrap(),
             PlayerError::IncorrectPlayerTurn,
         );
+
+        // This move has to be a valid choice on the board
         require(position < 9, PositionError::InvalidPosition);
         require(
             storage
                 .board
                 .get(position)
-                .try_read() == Option::None,
+                .unwrap()
+                .try_read() == None,
             PositionError::CellIsNotEmpty,
         );
 
-        storage.board.insert(position, msg_sender().unwrap());
-        storage.move_counter.write(storage.move_counter.read() + 1);
+        // Make the move and update positions and player
+        storage.board.set(position, Some(msg_sender().unwrap()));
+        let last_move_counter = storage.move_counter.read();
+        storage.move_counter.write(last_move_counter + 1);
 
+        let current_move_counter = last_move_counter + 1;
         let current_player = storage.player_turn.read().unwrap();
-        if (storage.player_turn.read().unwrap() == storage.player_one.read().unwrap())
-        {
-            storage.player_turn.write(storage.player_two.read());
+        let player_one = storage.player_one.read().unwrap();
+        let player_two = storage.player_two.read().unwrap();
+
+        if (current_player == player_one) {
+            storage.player_turn.write(Some(player_two));
         } else {
-            storage.player_turn.write(storage.player_one.read());
+            storage.player_turn.write(Some(player_one));
         }
 
-        if (storage.move_counter.read() > 4) {
-            let mut board = Vec::with_capacity(8);
-            let mut i = 0;
-            // We make a hard copy of the board to access the storage in an external function
-            // because we cannot pass in storage references.
-            // https://github.com/FuelLabs/sway/issues/3043
-            while (i < 9) {
-                board.push(storage.board.get(i).try_read());
-                i += 1;
-            }
-            if (win_check(board, current_player)) {
-                storage.player_turn.write(Option::None);
+        // Detemine if there is a winner or if it is a draw
+        if (current_move_counter > 4) {
+            let mut board = storage.board.load_vec();
+
+            if win_check(board, current_player) {
                 storage.state.write(State::Ended);
                 log(GameWonEvent {
                     player: msg_sender().unwrap(),
                 });
-            } else if draw(
-                    board,
-                    storage
-                        .player_one
-                        .read()
-                        .unwrap(),
-                    storage
-                        .player_two
-                        .read()
-                        .unwrap(),
-                    storage
-                        .move_counter
-                        .read(),
-                )
+            } else if draw(board, player_one, player_two, current_move_counter)
             {
-                storage.player_turn.write(Option::None);
                 storage.state.write(State::Ended);
                 log(GameDrawnEvent {
-                    player_one: storage.player_one.read().unwrap(),
-                    player_two: storage.player_two.read().unwrap(),
+                    player_one,
+                    player_two,
                 });
             }
         }
+    }
+
+    #[storage(read)]
+    fn get_board() -> Vec<Option<Identity>> {
+        storage.board.load_vec()
     }
 }

--- a/games/TicTacToe/project/contracts/tictactoe-contract/src/main.sw
+++ b/games/TicTacToe/project/contracts/tictactoe-contract/src/main.sw
@@ -127,4 +127,33 @@ impl Game for Contract {
     fn get_board() -> Vec<Option<Identity>> {
         storage.board.load_vec()
     }
+
+    #[storage(read)]
+    fn get_game_state() -> State {
+        storage.state.read()
+    }
+
+    #[storage(read)]
+    fn get_current_player() -> Option<Identity> {
+        match storage.state.read() {
+            State::Playing => {
+                storage.player_turn.read()
+            },
+            State::Ended => {
+                None
+            }
+        }
+    }
+
+    #[storage(read)]
+    fn get_players() -> Option<(Identity, Identity)> {
+        match storage.state.read() {
+            State::Playing => {
+                Some((storage.player_one.read().unwrap(), storage.player_two.read().unwrap()))
+            },
+            State::Ended => {
+                None
+            }
+        }
+    }
 }

--- a/games/TicTacToe/project/contracts/tictactoe-contract/src/main.sw
+++ b/games/TicTacToe/project/contracts/tictactoe-contract/src/main.sw
@@ -80,7 +80,8 @@ impl Game for Contract {
                 .board
                 .get(position)
                 .unwrap()
-                .try_read() == None,
+                .try_read()
+                .unwrap() == None,
             PositionError::CellIsNotEmpty,
         );
 


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- New feature
- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Reduces the number of reads and writes in the TicTacToe game by pushing them ad variables to the stack or adding them to the heap.
- Adds the `get_board()` function to return the current board and positions.
- Adds the `get_game_state()` function to return the current state of the game.
- Adds the `get_current_player()` function to return the current players turn.
- Adds the `get_players()` function to return the current players.
- Changes the board in storage from a `StorageMap` to a `StorageVec`.
- Adds missing inline docs
- Adds missing comments

## Notes

- A view function to retrieve the current state of the game was requested by an internal team member