### PR TITLE
Update links for Sway-Libs Book

### DIFF
--- a/NFT/README.md
+++ b/NFT/README.md
@@ -22,15 +22,15 @@ In this barebones NFT example project, there are a maximum of 100,000 NFTs that 
 
 ## Standards Implementations
 
-The project implements and follows the [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset), [SRC-3; Mint and Burn](https://github.com/FuelLabs/sway-standards/tree/master/standards/src3-mint-burn), and [SRC-7; Metadata](https://github.com/FuelLabs/sway-standards/tree/master/standards/src7-metadata) standards. It also uses the [Native Asset Library](https://github.com/FuelLabs/sway-libs/tree/master/libs/native-asset) to implement the basic functionality behind the standards.  
+The project implements and follows the [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md), [SRC-3; Mint and Burn](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md), and [SRC-7; Metadata](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standards. It also uses the [Native Asset Library](https://fuellabs.github.io/sway-libs/book/asset/index.html) to implement the basic functionality behind the standards.  
 
 ### SRC-20
 
-The [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset) standard requires that there is a maximum number of one coin per NFT asset. It also states that the decimals must be `0u8` for any NFT. This project conforms to both these restrictions and thus can be deemed an NFT on the Fuel Network. 
+The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard requires that there is a maximum number of one coin per NFT asset. It also states that the decimals must be `0u8` for any NFT. This project conforms to both these restrictions and thus can be deemed an NFT on the Fuel Network. 
 
 Set functions for name and symbol have been provided to the user. While traditionally name and symbol are written into the contract rather than storage, this contract is open to mint new types of assets. This means that every NFT minted by this contract may contain a different name and symbol. 
 
-The [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset) ABI defined below has also been implemented.
+The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) ABI defined below has also been implemented.
 
 ```sway
 abi SRC20 {
@@ -49,7 +49,7 @@ abi SRC20 {
 
 ### SRC-3
 
-The [SRC-3](https://github.com/FuelLabs/sway-standards/tree/master/standards/src3-mint-burn) standard defines the ABI for minting and burning. This has been properly implemented.
+The [SRC-3](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) standard defines the ABI for minting and burning. This has been properly implemented.
 
 ```sway
 abi SRC3 {
@@ -62,7 +62,7 @@ abi SRC3 {
 
 ### SRC-7
 
-The [SRC-7](https://github.com/FuelLabs/sway-standards/tree/master/standards/src7-metadata) standard defines the ABI for retrieving metadata. This has been properly implemented. 
+The [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standard defines the ABI for retrieving metadata. This has been properly implemented. 
 
 A set function that uses storage has been provided to allow the user to set their own desired metadata. There is no limit or restrictions to what and the amount of metadata an asset may have.
 

--- a/airdrop/README.md
+++ b/airdrop/README.md
@@ -23,7 +23,7 @@ An airdrop is an application where a set number of users are able to claim a spe
 
 In order to verifiably prove that a user has a claim to an airdrop and avoiding the expensive transaction of storing every address on chain, a Merkle Proof is used. By storing the Merkle root, a single `b256` hash, the airdrop application can cryptographically prove a user's validity to their claim.
 
-> **Note** This application implements the [Binary Merkle Proof Verification Library](https://github.com/FuelLabs/sway-libs/tree/master/libs/merkle_proof).
+This application implements the [Binary Merkle Proof Verification Library](https://fuellabs.github.io/sway-libs/book/merkle/index.html).
 
 More information can be found in the [specification](SPECIFICATION.md) and [interface](./airdrop-contract/src/interface.sw).
 

--- a/fractional-NFT/README.md
+++ b/fractional-NFT/README.md
@@ -22,11 +22,11 @@ In this barebones F-NFT example project, where locking a NFT into the vault will
 
 ## Standards Implementations
 
-The project implements and follows the [SRC-6; Vault](https://github.com/FuelLabs/sway-standards/tree/master/standards/src6-vault) and [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset) standards. 
+The project implements and follows the [SRC-6; Vault](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-6.md) and [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standards. 
 
 ### SRC-6
 
-The [SRC-6](https://github.com/FuelLabs/sway-standards/tree/master/standards/src6-vault) standard defines the ABI for locking an NFT in a vault and minting shares. This has been properly implemented.
+The [SRC-6](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-6.md) standard defines the ABI for locking an NFT in a vault and minting shares. This has been properly implemented.
 
 ```sway
 abi SRC6 {
@@ -47,7 +47,7 @@ abi SRC6 {
 
 ### SRC-20
 
-The [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_20) standard has been implemented for the resulting minted shares when a NFT is locked in the vault. Information on the share assets can be queried with the [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_20) standard.
+The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard has been implemented for the resulting minted shares when a NFT is locked in the vault. Information on the share assets can be queried with the [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard.
 
 ```sway
 abi SRC20 {

--- a/native-asset/README.md
+++ b/native-asset/README.md
@@ -22,13 +22,13 @@ In this project, there are a maximum of 100,000,000 coins for each asset that ma
 
 ## Standards Implementations
 
-The project implements and follows the [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset) and [SRC-3; Mint and Burn](https://github.com/FuelLabs/sway-standards/tree/master/standards/src3-mint-burn) standards. It also uses the [Native Asset Library](https://github.com/FuelLabs/sway-libs/blob/master/libs/native_assets) to implement the basic functionality behind the standards.  
+The project implements and follows the [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) and [SRC-3; Mint and Burn](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) standards. It also uses the [Native Asset Library](https://fuellabs.github.io/sway-libs/book/asset/index.html) to implement the basic functionality behind the standards.  
 
 ### SRC-20
 
 Set functions for name, symbol, and decimals have been provided to the user. While traditionally name, symbol, and decimals are written into the contract rather than storage, this contract is open to mint new types of assets. This means that every asset minted by this contract may contain a different name and symbol. 
 
-The [SRC-20](https://github.com/FuelLabs/sway-standards/tree/master/standards/src20-native-asset) ABI defined below has also been implemented.
+The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) ABI defined below has also been implemented.
 
 ```sway
 abi SRC20 {
@@ -47,7 +47,7 @@ abi SRC20 {
 
 ### SRC-3
 
-The [SRC-3](https://github.com/FuelLabs/sway-standards/tree/master/standards/src_3) standard defines the ABI for minting and burning. This has been properly implemented.
+The [SRC-3](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) standard defines the ABI for minting and burning. This has been properly implemented.
 
 ```sway
 abi SRC3 {


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Bug fix
- Documentation

## Changes

The following changes have been made:

- The Sway-Libs book has recently been released. Any references to the Sway-Libs repo have been replaced with the Sway-Libs Book
- The folder structure of the Sway-Standards repo has recently changed. Any references to the Sway-Standards have been updated

Closes #788 
