### PR TITLE
Remove Syntax Highlighting Sway Files as Rust

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,0 @@
-# Syntax highlighting of sway files as rust
-*.sw linguist-language=Rust


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Removed the .gitattributes file

## Notes

- GitHub recognizes sway files as does not need them to be marked as Rust files
