### PR TITLE
Update to use latest SRC-20 and SRC-3 specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Description of the upcoming release here.
 ### Changed
 
 - [#809](https://github.com/FuelLabs/sway-applications/issues/809) Set Devrel team as codeowners
-- Something changed here 2
+- [#811](https://github.com/FuelLabs/sway-applications/pull/811) Updates the NFT, Fractional NFT, and Native Asset apps to the latest SRC-20 and SRC-3 specs.
 
 ### Fixed
 

--- a/NFT/Forc.lock
+++ b/NFT/Forc.lock
@@ -2,7 +2,7 @@
 name = "NFT-contract"
 source = "member"
 dependencies = [
-    "standards",
+    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.6.1#792639cdf391565e6e6a02482ea8a46d9604a6f5",
     "std",
     "sway_libs",
 ]
@@ -13,7 +13,12 @@ source = "path+from-root-E19CE48B3E858B72"
 
 [[package]]
 name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.4.3#6f63eb7dff2458a7d976184e565b5cbf26f61da2"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c"
+dependencies = ["std"]
+
+[[package]]
+name = "standards"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.1#792639cdf391565e6e6a02482ea8a46d9604a6f5"
 dependencies = ["std"]
 
 [[package]]
@@ -23,8 +28,8 @@ dependencies = ["core"]
 
 [[package]]
 name = "sway_libs"
-source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.21.0#6a227ed34c86fe1ebd334dbdfeccf66c43e3915b"
+source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.24.0#e19f96f85ae12426d20adc176b70aa38fd9a2a5b"
 dependencies = [
-    "standards",
+    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c",
     "std",
 ]

--- a/NFT/NFT-contract/Forc.toml
+++ b/NFT/NFT-contract/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "NFT-contract"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.21.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.0" }

--- a/NFT/NFT-contract/src/errors.sw
+++ b/NFT/NFT-contract/src/errors.sw
@@ -4,6 +4,7 @@ pub enum MintError {
     CannotMintMoreThanOneNFTWithSubId: (),
     MaxNFTsMinted: (),
     NFTAlreadyMinted: (),
+    SubIdNone: (),
 }
 
 pub enum SetError {

--- a/NFT/NFT-contract/src/main.sw
+++ b/NFT/NFT-contract/src/main.sw
@@ -304,7 +304,8 @@ impl SRC3 for Contract {
             storage
                 .total_supply,
             recipient,
-            sub_id,
+            sub_id
+                .unwrap(),
             amount,
         );
     }
@@ -704,6 +705,6 @@ impl EmitSRC20Events for Contract {
         // Metadata that is stored as a configurable should only be emitted once.
         let sender = msg_sender().unwrap();
 
-        SetDecimalsEvent::new(asset, DECIMALS, sender).log();
+        SetDecimalsEvent::new(asset, 0u8, sender).log();
     }
 }

--- a/NFT/NFT-contract/src/main.sw
+++ b/NFT/NFT-contract/src/main.sw
@@ -5,7 +5,21 @@ mod interface;
 
 use errors::{MintError, SetError};
 use interface::Constructor;
-use standards::{src20::{SetDecimalsEvent, SRC20}, src3::SRC3, src5::{SRC5, State}, src7::{Metadata, SRC7},};
+use standards::{
+    src20::{
+        SetDecimalsEvent,
+        SRC20,
+    },
+    src3::SRC3,
+    src5::{
+        SRC5,
+        State,
+    },
+    src7::{
+        Metadata,
+        SRC7,
+    },
+};
 use sway_libs::{
     asset::{
         base::{

--- a/NFT/NFT-contract/tests/utils/interface.rs
+++ b/NFT/NFT-contract/tests/utils/interface.rs
@@ -51,7 +51,7 @@ pub(crate) async fn mint(
 ) -> FuelCallResponse<()> {
     contract
         .methods()
-        .mint(recipient, sub_id, amount)
+        .mint(recipient, Some(sub_id), amount)
         .append_variable_outputs(1)
         .call()
         .await

--- a/NFT/README.md
+++ b/NFT/README.md
@@ -22,15 +22,15 @@ In this barebones NFT example project, there are a maximum of 100,000 NFTs that 
 
 ## Standards Implementations
 
-The project implements and follows the [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md), [SRC-3; Mint and Burn](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md), and [SRC-7; Metadata](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standards. It also uses the [Native Asset Library](https://fuellabs.github.io/sway-libs/book/asset/index.html) to implement the basic functionality behind the standards.  
+The project implements and follows the [SRC-20; Native Asset](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/), [SRC-3; Mint and Burn](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/), and [SRC-7; Metadata](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) standards. It also uses the [Native Asset Library](https://docs.fuel.network/docs/sway-libs/asset/) to implement the basic functionality behind the standards.  
 
 ### SRC-20
 
-The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard requires that there is a maximum number of one coin per NFT asset. It also states that the decimals must be `0u8` for any NFT. This project conforms to both these restrictions and thus can be deemed an NFT on the Fuel Network. 
+The [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard requires that there is a maximum number of one coin per NFT asset. It also states that the decimals must be `0u8` for any NFT. This project conforms to both these restrictions and thus can be deemed an NFT on the Fuel Network. 
 
 Set functions for name and symbol have been provided to the user. While traditionally name and symbol are written into the contract rather than storage, this contract is open to mint new types of assets. This means that every NFT minted by this contract may contain a different name and symbol. 
 
-The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) ABI defined below has also been implemented.
+The [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) ABI defined below has also been implemented.
 
 ```sway
 abi SRC20 {
@@ -49,7 +49,7 @@ abi SRC20 {
 
 ### SRC-3
 
-The [SRC-3](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) standard defines the ABI for minting and burning. This has been properly implemented.
+The [SRC-3](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) standard defines the ABI for minting and burning. This has been properly implemented.
 
 ```sway
 abi SRC3 {
@@ -62,7 +62,7 @@ abi SRC3 {
 
 ### SRC-7
 
-The [SRC-7](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-7.md) standard defines the ABI for retrieving metadata. This has been properly implemented. 
+The [SRC-7](https://docs.fuel.network/docs/sway-standards/src-7-asset-metadata/) standard defines the ABI for retrieving metadata. This has been properly implemented. 
 
 A set function that uses storage has been provided to allow the user to set their own desired metadata. There is no limit or restrictions to what and the amount of metadata an asset may have.
 

--- a/fractional-NFT/Forc.lock
+++ b/fractional-NFT/Forc.lock
@@ -15,7 +15,7 @@ source = "path+from-root-E19CE48B3E858B72"
 name = "f-NFT-contract"
 source = "member"
 dependencies = [
-    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.4.4#a001d3c248595112aae67e5633a06ef9bc0536ae",
+    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.6.1#792639cdf391565e6e6a02482ea8a46d9604a6f5",
     "std",
 ]
 
@@ -27,6 +27,11 @@ dependencies = ["std"]
 [[package]]
 name = "standards"
 source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.4.4#a001d3c248595112aae67e5633a06ef9bc0536ae"
+dependencies = ["std"]
+
+[[package]]
+name = "standards"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.1#792639cdf391565e6e6a02482ea8a46d9604a6f5"
 dependencies = ["std"]
 
 [[package]]

--- a/fractional-NFT/Forc.lock
+++ b/fractional-NFT/Forc.lock
@@ -2,7 +2,7 @@
 name = "NFT-contract"
 source = "member"
 dependencies = [
-    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.4.4#a001d3c248595112aae67e5633a06ef9bc0536ae",
+    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.6.1#792639cdf391565e6e6a02482ea8a46d9604a6f5",
     "std",
     "sway_libs",
 ]
@@ -21,12 +21,7 @@ dependencies = [
 
 [[package]]
 name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.4.3#6f63eb7dff2458a7d976184e565b5cbf26f61da2"
-dependencies = ["std"]
-
-[[package]]
-name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.4.4#a001d3c248595112aae67e5633a06ef9bc0536ae"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c"
 dependencies = ["std"]
 
 [[package]]
@@ -41,8 +36,8 @@ dependencies = ["core"]
 
 [[package]]
 name = "sway_libs"
-source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.21.0#6a227ed34c86fe1ebd334dbdfeccf66c43e3915b"
+source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.24.0#e19f96f85ae12426d20adc176b70aa38fd9a2a5b"
 dependencies = [
-    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.4.3#6f63eb7dff2458a7d976184e565b5cbf26f61da2",
+    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c",
     "std",
 ]

--- a/fractional-NFT/README.md
+++ b/fractional-NFT/README.md
@@ -22,7 +22,7 @@ In this barebones F-NFT example project, where locking a NFT into the vault will
 
 ## Standards Implementations
 
-The project implements and follows the [SRC-6; Vault](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-6.md) and [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standards. 
+The project implements and follows the [SRC-6; Vault](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-6.md) and [SRC-20; Native Asset](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standards. 
 
 ### SRC-6
 
@@ -47,7 +47,7 @@ abi SRC6 {
 
 ### SRC-20
 
-The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard has been implemented for the resulting minted shares when a NFT is locked in the vault. Information on the share assets can be queried with the [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) standard.
+The [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard has been implemented for the resulting minted shares when a NFT is locked in the vault. Information on the share assets can be queried with the [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) standard.
 
 ```sway
 abi SRC20 {

--- a/fractional-NFT/f-NFT-contract/Forc.toml
+++ b/fractional-NFT/f-NFT-contract/Forc.toml
@@ -5,4 +5,4 @@ license = "Apache-2.0"
 name = "f-NFT-contract"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.4" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.1" }

--- a/fractional-NFT/f-NFT-contract/src/main.sw
+++ b/fractional-NFT/f-NFT-contract/src/main.sw
@@ -3,7 +3,20 @@ contract;
 mod errors;
 
 use errors::{DepositError, SubIdError, WithdrawError};
-use standards::{src20::SRC20, src6::{Deposit, SRC6, Withdraw}};
+use standards::{
+    src20::{
+        SetDecimalsEvent,
+        SetNameEvent,
+        SetSymbolEvent,
+        SRC20,
+        TotalSupplyEvent,
+    },
+    src6::{
+        Deposit,
+        SRC6,
+        Withdraw,
+    },
+};
 use std::{
     asset::{
         burn,
@@ -475,7 +488,7 @@ impl SRC20 for Contract {
 }
 
 abi EmitSRC20Events {
-    fn emit_src20_events();
+    fn emit_src20_events(asset: AssetId);
 }
 
 impl EmitSRC20Events for Contract {

--- a/fractional-NFT/f-NFT-contract/tests/utils/setup.rs
+++ b/fractional-NFT/f-NFT-contract/tests/utils/setup.rs
@@ -144,13 +144,13 @@ pub(crate) async fn setup_nft(
 
     let _ = nft
         .methods()
-        .mint(identity, Bits256(*sub_id_1), 1)
+        .mint(identity, Some(Bits256(*sub_id_1)), 1)
         .append_variable_outputs(1)
         .call()
         .await;
     let _ = nft
         .methods()
-        .mint(identity, Bits256(*sub_id_2), 1)
+        .mint(identity, Some(Bits256(*sub_id_2)), 1)
         .append_variable_outputs(1)
         .call()
         .await;

--- a/fractional-NFT/test-artifacts/Forc.toml
+++ b/fractional-NFT/test-artifacts/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "NFT-contract"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.4" }
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.21.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.0" }

--- a/fractional-NFT/test-artifacts/src/main.sw
+++ b/fractional-NFT/test-artifacts/src/main.sw
@@ -228,8 +228,8 @@ impl SRC3 for Contract {
     /// }
     /// ```
     #[storage(read, write)]
-    fn mint(recipient: Identity, sub_id: SubId, amount: u64) {
-        let asset = AssetId::new(ContractId::this(), sub_id);
+    fn mint(recipient: Identity, sub_id: Option<SubId>, amount: u64) {
+        let asset = AssetId::new(ContractId::this(), sub_id.unwrap());
         require(amount == 1, MintError::CannotMintMoreThanOneNFTWithSubId);
         require(
             storage

--- a/fractional-NFT/test-artifacts/src/main.sw
+++ b/fractional-NFT/test-artifacts/src/main.sw
@@ -252,7 +252,7 @@ impl SRC3 for Contract {
             storage
                 .total_supply,
             recipient,
-            sub_id,
+            sub_id.unwrap(),
             amount,
         );
     }

--- a/fractional-NFT/test-artifacts/src/main.sw
+++ b/fractional-NFT/test-artifacts/src/main.sw
@@ -252,7 +252,8 @@ impl SRC3 for Contract {
             storage
                 .total_supply,
             recipient,
-            sub_id.unwrap(),
+            sub_id
+                .unwrap(),
             amount,
         );
     }

--- a/native-asset/Forc.lock
+++ b/native-asset/Forc.lock
@@ -6,14 +6,19 @@ source = "path+from-root-E19CE48B3E858B72"
 name = "native-asset-contract"
 source = "member"
 dependencies = [
-    "standards",
+    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.6.1#792639cdf391565e6e6a02482ea8a46d9604a6f5",
     "std",
     "sway_libs",
 ]
 
 [[package]]
 name = "standards"
-source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.4.3#6f63eb7dff2458a7d976184e565b5cbf26f61da2"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c"
+dependencies = ["std"]
+
+[[package]]
+name = "standards"
+source = "git+https://github.com/FuelLabs/sway-standards?tag=v0.6.1#792639cdf391565e6e6a02482ea8a46d9604a6f5"
 dependencies = ["std"]
 
 [[package]]
@@ -23,8 +28,8 @@ dependencies = ["core"]
 
 [[package]]
 name = "sway_libs"
-source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.21.0#6a227ed34c86fe1ebd334dbdfeccf66c43e3915b"
+source = "git+https://github.com/FuelLabs/sway-libs?tag=v0.24.0#e19f96f85ae12426d20adc176b70aa38fd9a2a5b"
 dependencies = [
-    "standards",
+    "standards git+https://github.com/FuelLabs/sway-standards?tag=v0.6.0#65e09f95ea8b9476b171a66c8a47108f352fa32c",
     "std",
 ]

--- a/native-asset/README.md
+++ b/native-asset/README.md
@@ -22,13 +22,13 @@ In this project, there are a maximum of 100,000,000 coins for each asset that ma
 
 ## Standards Implementations
 
-The project implements and follows the [SRC-20; Native Asset](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) and [SRC-3; Mint and Burn](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) standards. It also uses the [Native Asset Library](https://fuellabs.github.io/sway-libs/book/asset/index.html) to implement the basic functionality behind the standards.  
+The project implements and follows the [SRC-20; Native Asset](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) and [SRC-3; Mint and Burn](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) standards. It also uses the [Native Asset Library](https://docs.fuel.network/docs/sway-libs/asset/) to implement the basic functionality behind the standards.  
 
 ### SRC-20
 
 Set functions for name, symbol, and decimals have been provided to the user. While traditionally name, symbol, and decimals are written into the contract rather than storage, this contract is open to mint new types of assets. This means that every asset minted by this contract may contain a different name and symbol. 
 
-The [SRC-20](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-20.md) ABI defined below has also been implemented.
+The [SRC-20](https://docs.fuel.network/docs/sway-standards/src-20-native-asset/) ABI defined below has also been implemented.
 
 ```sway
 abi SRC20 {
@@ -47,7 +47,7 @@ abi SRC20 {
 
 ### SRC-3
 
-The [SRC-3](https://github.com/FuelLabs/sway-standards/blob/master/SRCs/src-3.md) standard defines the ABI for minting and burning. This has been properly implemented.
+The [SRC-3](https://docs.fuel.network/docs/sway-standards/src-3-minting-and-burning/) standard defines the ABI for minting and burning. This has been properly implemented.
 
 ```sway
 abi SRC3 {

--- a/native-asset/native-asset-contract/Forc.toml
+++ b/native-asset/native-asset-contract/Forc.toml
@@ -5,5 +5,5 @@ license = "Apache-2.0"
 name = "native-asset-contract"
 
 [dependencies]
-standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.4.3" }
-sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.21.0" }
+standards = { git = "https://github.com/FuelLabs/sway-standards", tag = "v0.6.1" }
+sway_libs = { git = "https://github.com/FuelLabs/sway-libs", tag = "v0.24.0" }

--- a/native-asset/native-asset-contract/src/errors.sw
+++ b/native-asset/native-asset-contract/src/errors.sw
@@ -6,6 +6,7 @@ pub enum AmountError {
 
 pub enum MintError {
     MaxMinted: (),
+    SubIdNone: (),
 }
 
 pub enum SetError {

--- a/native-asset/native-asset-contract/src/main.sw
+++ b/native-asset/native-asset-contract/src/main.sw
@@ -262,7 +262,8 @@ impl SRC3 for Contract {
             storage
                 .total_supply,
             recipient,
-            sub_id.unwrap(),
+            sub_id
+                .unwrap(),
             amount,
         );
     }

--- a/native-asset/native-asset-contract/tests/utils/interface.rs
+++ b/native-asset/native-asset-contract/tests/utils/interface.rs
@@ -57,7 +57,7 @@ pub(crate) async fn mint(
 ) -> FuelCallResponse<()> {
     contract
         .methods()
-        .mint(recipient, sub_id, amount)
+        .mint(recipient, Some(sub_id), amount)
         .append_variable_outputs(1)
         .call()
         .await


### PR DESCRIPTION
## Type of change

<!--Delete points that do not apply-->

- Improvement (refactoring, restructuring repository, cleaning tech debt, ...)

## Changes

The following changes have been made:

- Updates the fractional NFT app to use the latest SRC-20 specs that include logging events
- Updates the NFT app to use the latest SRC-20 specs that include logging events
- Updates the NFT app to use the latest SRC-3 specs that use an `Option` for the `sub_id` argument
- Updates the native asset app to use the latest SRC-20 apecs that include logging events
- Updates the native asset app to use the latest SRC-3 specs that use an `Option` for the `sub_id` argument
- Updates READMEs to use docs hub over github

## Checklist

- [x] I have linked to any relevant issues.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have updated the documentation where relevant (API docs, the reference, and the Sway book).
   - [ ] If my change requires substantial documentation changes, I have [requested support from the DevRel team](https://github.com/FuelLabs/devrel-requests/issues/new/choose)
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added (or requested a maintainer to add) the necessary `Breaking*` or `New Feature` labels where relevant.
- [x] I have done my best to ensure that my PR adheres to [the Fuel Labs Code Review Standards](https://github.com/FuelLabs/rfcs/blob/master/text/code-standards/external-contributors.md).
- [x] I have requested a review from the relevant team or maintainers.
- [x] I have updated the changelog to reflect the changes on this PR.
